### PR TITLE
Fix taskrun pruning in workload cluster

### DIFF
--- a/gitops/argocd/tektoncd/allow-argocd-to-manage.yaml
+++ b/gitops/argocd/tektoncd/allow-argocd-to-manage.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-gitops-apply-tekton-config-parameters
+rules:
+  - apiGroups:
+      - operator.tekton.dev
+    resources:
+      - tektonconfigs
+    verbs:
+      - get
+      - list
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-gitops-apply-tekton-config-parameters
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-gitops-apply-tekton-config-parameters
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops

--- a/gitops/argocd/tektoncd/kustomization.yaml
+++ b/gitops/argocd/tektoncd/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - allow-argocd-to-manage.yaml
   - openshift-operator.yaml
-  # Due to some permission issue probably, the TektonConfig is not being applied properly, commenting till the issue is resolved. 
-  # - tekton-config.yaml
+  - tekton-config.yaml

--- a/gitops/argocd/tektoncd/tekton-config.yaml
+++ b/gitops/argocd/tektoncd/tekton-config.yaml
@@ -2,6 +2,11 @@ apiVersion: operator.tekton.dev/v1alpha1
 kind: TektonConfig
 metadata:
   name: config
+  annotations:
+    # An ArgoCD wave annotation ensures that some resources are always ready
+    # before next step. By default everything is a part of wave "0".
+    # Refer <https://argo-cd.readthedocs.io/en/release-1.8/user-guide/sync-waves/> 
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   profile: all
   targetNamespace: openshift-pipelines
@@ -9,7 +14,10 @@ spec:
     enable-tekton-oci-bundles: true
   pruner:
     resources:
+      # Only prune taskruns until re-reconciling of resources is fixed.
       - taskrun
-    keep: 100
-    # Run the TaskRun pruner every day at 0800 Hrs (8:00 AM) system time. Refer <https://en.wikipedia.org/wiki/Cron> for detailed Cron format.
+    # Retain resources younger than 2 days (2880 mins)
+    keep-since: 2880
+    # Run the TaskRun pruner every day at 0800 Hrs (8:00 AM) system time.
+    # Refer <https://en.wikipedia.org/wiki/Cron> for detailed Cron format.
     schedule: "0 8 * * *"


### PR DESCRIPTION
## Changes

- Only prune taskruns
- Added ClusterRole and ClusterRoleBinding for granting permission to
  argocd serviceaccount to be able to patch TektonConfig
- Added sync wave to the TektonConfig patch for precaution, ensures
  that TektonConfig CRD is available before patching
- Fixes PLNSRVCE-355

## Results

### ServiceAccount Permissions

```sh
k auth can-i --list   --as=system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller | grep tektonconfigs
tektonconfigs.operator.tekton.dev                                    []                                          []               [get watch list patch]
``` 

### TektonConfig

```yaml
apiVersion: v1
items:
- apiVersion: operator.tekton.dev/v1alpha1
  kind: TektonConfig
  metadata:
    annotations:
      argocd.argoproj.io/sync-wave: "1"
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"operator.tekton.dev/v1alpha1","kind":"TektonConfig","metadata":{"annotations":{"argocd.argoproj.io/sync-wave":"1"},"labels":{"app.kubernetes.io/instance":"tektoncd"},"name":"config"},"spec":{"pipeline":{"enable-tekton-oci-bundles":true},"profile":"all","pruner":{"keep":100,"resources":["taskrun"],"schedule":"0 8 * * *"},"targetNamespace":"openshift-pipelines"}}
    creationTimestamp: "2022-08-04T06:19:23Z"
    finalizers:
    - tektonconfigs.operator.tekton.dev
    generation: 3
    labels:
      app.kubernetes.io/instance: tektoncd
      operator.tekton.dev/release-version: 1.7.2
    name: config
    resourceVersion: "64709"
    uid: d47b8e9c-4635-44d2-b4d2-948215531cda
  spec:
    addon:
      enablePipelinesAsCode: true
      params:
      - name: clusterTasks
        value: "true"
      - name: pipelineTemplates
        value: "true"
      - name: communityClusterTasks
        value: "true"
    config: {}
    dashboard:
      readonly: false
    hub: {}
    params:
    - name: createRbacResource
      value: "true"
    pipeline:
      default-service-account: pipeline
      disable-affinity-assistant: true
      disable-creds-init: false
      enable-api-fields: stable
      enable-custom-tasks: false
      enable-tekton-oci-bundles: true
      metrics.pipelinerun.duration-type: histogram
      metrics.pipelinerun.level: pipeline
      metrics.taskrun.duration-type: histogram
      metrics.taskrun.level: task
      params:
      - name: enableMetrics
        value: "true"
      require-git-ssh-secret-known-hosts: false
      running-in-environment-with-injected-sidecars: true
      scope-when-expressions-to-task: false
    profile: all
    pruner:
      keep: 100
      resources:
      - taskrun
      schedule: 0 8 * * *
    targetNamespace: openshift-pipelines
    trigger:
      default-service-account: pipeline
      enable-api-fields: stable
  status:
    conditions:
    - lastTransitionTime: "2022-08-04T06:47:55Z"
      status: "True"
      type: ComponentsReady
    - lastTransitionTime: "2022-08-04T06:21:57Z"
      status: "True"
      type: PostInstall
    - lastTransitionTime: "2022-08-04T06:19:36Z"
      status: "True"
      type: PreInstall
    - lastTransitionTime: "2022-08-04T06:47:55Z"
      status: "True"
      type: Ready
    tektonInstallerSets:
      rhosp-rbac: rhosp-rbac-dtg6s
    version: 1.7.2
kind: List
metadata:
  resourceVersion: ""
```

## References

- https://github.com/gnunn-gitops/cluster-config/blob/main/components/apps/pipelines-operator/overlays/patch-config-parameters/patch-config-parameters-sa.yaml

Signed-off-by: Avinal Kumar <avinal@redhat.com>
