### PR TITLE
local dev: Switch to the imperative creation of organization workspace

### DIFF
--- a/local/kcp/pipelines-service-org.yaml
+++ b/local/kcp/pipelines-service-org.yaml
@@ -1,8 +1,0 @@
-apiVersion: tenancy.kcp.dev/v1alpha1
-kind: ClusterWorkspace
-metadata:
-  name: pipeline-service
-spec:
-  type:
-    name: organization
-    path: root

--- a/local/kcp/start.sh
+++ b/local/kcp/start.sh
@@ -90,7 +90,7 @@ create-org() {
   printf "Creating organization\n"
   kubectl --kubeconfig="${KUBECONFIG}" config use-context root
   KUBECONFIG="${KUBECONFIG}" ${KCP_DIR}/bin/kubectl-kcp workspace use root
-  kubectl --kubeconfig="${KUBECONFIG}" create -f "${PARENT_PATH}/pipelines-service-org.yaml"
+  KUBECONFIG="${KUBECONFIG}" ${KCP_DIR}/bin/kubectl-kcp workspace create --type=organization pipeline-service --enter
 }
 
 # Execution
@@ -123,6 +123,7 @@ fi
 kcp-start
 printf "KUBECONFIG=%s\n" "${KUBECONFIG}"
 printf "kubectl kcp plugin (should be copied to kubectl binary location): %s\n" "${KCP_DIR}/bin/kubectl-kcp"
+# old ingress PoC is not working anymore, waiting for kcp-glbc to be usable.
 # ingress-ctrler-start
 # envoy-start
 create-org


### PR DESCRIPTION
Switch to the imperative creation of organization workspace to get the new RBAC (clusterrole and clusterrolebinding in root workspace) automatically set up.

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>