### PR TITLE
ckcp: Optimize resource requests and limits

### DIFF
--- a/ckcp/openshift/base/deployment.yaml
+++ b/ckcp/openshift/base/deployment.yaml
@@ -40,8 +40,8 @@ spec:
           limits:
             memory: 2Gi
           requests:
-            cpu: '1'
-            memory: 1Gi
+            cpu: 100m
+            memory: 178Mi
         volumeMounts:
         - name: kcp-certs
           mountPath: /etc/kcp/tls/server


### PR DESCRIPTION
kcp-in-container (ckcp) currently has CPU and memory requests that make
it difficult to schedule on a standard IPI cluster. In testing, the
following behavior was observed:

- Initial memory usage hits 177Mi, is never lower.
- kcp memory increases to ~500Mi once syncer is deployed.
- CPU usage rarely exceeds 0.1 CPU per minute. 100m CPU request is
typical for a system workload.

Partially addresses #118 