### PR TITLE
fixed shellcheck issue SC2034 

### DIFF
--- a/images/access-setup/content/bin/common.sh
+++ b/images/access-setup/content/bin/common.sh
@@ -38,7 +38,7 @@ get_context() {
     exit 1
   fi
 
-  for i in {1..5}
+  for _ in {1..5}
   do
     token_secret="$(KUBECONFIG="$target" kubectl get sa "$sa" -n "$namespace" -o json |
       jq -r '.secrets[]?.name | select(. | test(".*token.*"))')"


### PR DESCRIPTION
**Issue:**
shellcheck reported the following issue:
```
In ./images/access-setup/content/bin/common.sh line 41:
  for i in {1..5}
  ^-^ SC2034: i appears unused. Verify use (or export if used externally).
```

**Solution:**
use the name `_` as variable , I found the solution from this [link](https://github.com/koalaman/shellcheck/issues/1134)