### PR TITLE
Explicitly set the type by workspace creation

### DIFF
--- a/images/access-setup/content/bin/setup_kcp.sh
+++ b/images/access-setup/content/bin/setup_kcp.sh
@@ -143,7 +143,7 @@ generate_kcp_credentials() {
   printf "    - Create workspace:\n"
   kubectl kcp workspace use "$KCP_ORG"
   if ! kubectl kcp workspace use "$KCP_WORKSPACE" >/dev/null 2>&1; then
-    kubectl kcp workspace create "$KCP_WORKSPACE" --enter >/dev/null
+    kubectl kcp workspace create "$KCP_WORKSPACE" --type=universal --enter >/dev/null
   fi
   kubectl kcp workspace current
 

--- a/images/gateway-deployment/install.sh
+++ b/images/gateway-deployment/install.sh
@@ -79,7 +79,7 @@ switch_ws() {
 
     else
        printf "creating workspace %s\n" "${KCP_WORKSPACE}"
-       KUBECONFIG=${kcp_kcfg} kubectl kcp workspace create "${KCP_WORKSPACE}" --enter
+       KUBECONFIG=${kcp_kcfg} kubectl kcp workspace create "${KCP_WORKSPACE}" --type=universal --enter
     fi
 }
 

--- a/images/kcp-registrar/register.sh
+++ b/images/kcp-registrar/register.sh
@@ -177,7 +177,7 @@ switch_ws() {
         printf "  - Use existing workspace\n"
     else
         printf "  - Create workspace %s\n" "${KCP_WORKSPACE}"
-        KUBECONFIG="$kcp_kcfg" kubectl kcp workspace create "${KCP_WORKSPACE}" --enter >/dev/null 2>&1
+        KUBECONFIG="$kcp_kcfg" kubectl kcp workspace create "${KCP_WORKSPACE}" --type=universal --enter >/dev/null 2>&1
     fi
     KUBECONFIG="$kcp_kcfg" kubectl kcp workspace current
 }


### PR DESCRIPTION
This is for supporting the creation of compute workspaces under root (default is organization under root).

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>