### PR TITLE
fix issues that hadolint reported

### DIFF
--- a/images/access-setup/Dockerfile
+++ b/images/access-setup/Dockerfile
@@ -4,15 +4,16 @@ RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
 ENV HOME /tmp/home
 RUN mkdir $HOME && chmod 777 $HOME && chown 65532:65532 $HOME
 
-RUN microdnf install gzip tar
+RUN microdnf install -y gzip-1.9 tar-1.30 && microdnf clean all
 RUN JQ_VERSION=1.6 && \
     curl -sSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64 && \
     chmod 755 /usr/local/bin/jq
 RUN KUBE_VERSION=v1.24.0 && \
     curl -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/amd64/kubectl" && \
     chmod 755 /usr/local/bin/kubectl
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN KCP_VERSION=v0.7.4 && \
-    curl -L -o /tmp/kubectl-kcp.tgz "https://github.com/kcp-dev/kcp/releases/download/$KCP_VERSION/kubectl-kcp-plugin_${KCP_VERSION:1}_linux_amd64.tar.gz" && \
+    curl -L -o /tmp/kubectl-kcp.tgz "https://github.com/kcp-dev/kcp/releases/download/$KCP_VERSION/kubectl-kcp-plugin_$(printf '%s' "$KCP_VERSION" | sed 's/v//')_linux_amd64.tar.gz" && \
     tar -C /usr/local -xzvf /tmp/kubectl-kcp.tgz bin/kubectl-kcp && \
     rm /tmp/kubectl-kcp.tgz
 COPY content /opt/access-setup

--- a/images/cluster-setup/Dockerfile
+++ b/images/cluster-setup/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir $HOME && chmod 777 $HOME && chown 65532:65532 $HOME
 RUN KUBE_VERSION=v1.24.0 && \
     curl -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/amd64/kubectl" && \
     chmod 755 /usr/local/bin/kubectl
-RUN microdnf install findutils git
+RUN microdnf install -y findutils-4.6.0 git-2.31.1 && microdnf clean all
 COPY ./install.sh /usr/local/bin/install.sh
 USER 65532:65532
 VOLUME /workspace

--- a/images/kcp-registrar/Dockerfile
+++ b/images/kcp-registrar/Dockerfile
@@ -15,7 +15,7 @@ LABEL build-date= \
       vendor="Pipeline Service" \
       version="0.1"
 WORKDIR /
-RUN microdnf install findutils gzip tar
+RUN microdnf install -y findutils-4.6.0 gzip-1.9 tar-1.30 && microdnf clean all
 ARG KCP_BRANCH
 ENV KCP_SYNC_TAG=${KCP_BRANCH}
 ENV HOME /tmp/home
@@ -27,8 +27,9 @@ RUN JQ_VERSION=1.6 && \
 RUN KUBE_VERSION=v1.24.0 && \
     curl --fail -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/amd64/kubectl" && \
     chmod 755 /usr/local/bin/kubectl
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN KCP_VERSION=v0.7.4 && \
-    curl -L -o /tmp/kubectl-kcp.tgz "https://github.com/kcp-dev/kcp/releases/download/$KCP_VERSION/kubectl-kcp-plugin_${KCP_VERSION:1}_linux_amd64.tar.gz" && \
+    curl -L -o /tmp/kubectl-kcp.tgz "https://github.com/kcp-dev/kcp/releases/download/$KCP_VERSION/kubectl-kcp-plugin_$(printf '%s' "$KCP_VERSION" | sed 's/v//')_linux_amd64.tar.gz" && \
     tar -C /usr/local -xzvf /tmp/kubectl-kcp.tgz bin/kubectl-kcp && \
     rm /tmp/kubectl-kcp.tgz
 COPY ./register.sh /usr/local/bin/register.sh

--- a/test/images/shellcheck/Dockerfile
+++ b/test/images/shellcheck/Dockerfile
@@ -18,10 +18,11 @@ WORKDIR /
 RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
 ENV HOME /tmp/home
 RUN mkdir $HOME && chmod 777 $HOME && chown 65532:65532 $HOME
-RUN microdnf install tar xz findutils
-RUN SHELLCHECK_VERSION=0.7.1 && \
-    curl --fail -sSL  https://github.com/koalaman/shellcheck/releases/download/v$SHELLCHECK_VERSION/shellcheck-v$SHELLCHECK_VERSION.linux.x86_64.tar.xz | tar -xJvf - shellcheck-v$SHELLCHECK_VERSION/shellcheck && \
-    mv shellcheck-v$SHELLCHECK_VERSION/shellcheck /usr/local/bin/shellcheck && \
+RUN microdnf install -y tar-1.30 xz-5.2.4 findutils-4.6.0 && microdnf clean all
+RUN SHELLCHECK_VERSION=v0.7.1 && \
+    curl -L -o /tmp/shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/$SHELLCHECK_VERSION/shellcheck-$SHELLCHECK_VERSION.linux.x86_64.tar.xz" && \
+    tar -xJvf /tmp/shellcheck.tar.xz -C /tmp && \
+    mv /tmp/shellcheck-$SHELLCHECK_VERSION/shellcheck /usr/local/bin/shellcheck && \
     chmod 755 /usr/local/bin/shellcheck && \
     shellcheck -V
 USER 65532:65532


### PR DESCRIPTION
**Changes:**

Fixed Dockerfile issues that hadolint reported.

When this PR is merged, the CI [PR](https://github.com/openshift/release/pull/31602) can be merged and enable hadolint CI.

**Verify:**
Execute the following command to verify it
```
$ docker run -it --rm --mount type=bind,source="<path of pipelines-service >",target=/workspace ghcr.io/hadolint/hadolint:latest-debian find /workspace -name Dockerfile -exec hadolint -c test/config/hadolint.yaml {} +
```