### PR TITLE
bugfix: ckcp/test.sh

### DIFF
--- a/ckcp/test.sh
+++ b/ckcp/test.sh
@@ -1,28 +1,37 @@
 #!/usr/bin/env bash
 
 #quit if exit status of any cmd is a non-zero value
-set -exuo pipefail
+set -euo pipefail
+
+# Uncomment the below line to enable debugging
+# set -x
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null ; pwd)"
 KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 export KUBECONFIG=$KUBECONFIG
-KUBECONFIG_KCP="${KUBECONFIG_KCP:-$SCRIPT_DIR/work/kubeconfig/admin.kubeconfig}"
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-$SCRIPT_DIR/work/credentials/kubeconfig/kcp/ckcp-ckcp.default.pipeline-service-compute.kubeconfig}"
 
 get_namespace() {
   # Retrieve the KCP namespace id
   local ns_locator
-  ns_locator="{\"logical-cluster\":\"$(
+  ns_locator="\"workspace\":\"$(
     KUBECONFIG="$KUBECONFIG_KCP" kubectl kcp workspace current | cut -d\" -f2
-  )\",\"namespace\":\"default\"}"
+  )\",\"namespace\":\"default\""
   # Loop is necessary as it takes KCP time to create the namespace
   while ! kubectl get ns -o yaml | grep -q "$ns_locator"; do
     sleep 2
   done
+
   local KCP_NS_NAME
-  KCP_NS_NAME="$(kubectl get ns -l internal.workload.kcp.dev/cluster=local -o json \
-    | jq -r '.items[].metadata | select(.annotations."kcp.dev/namespace-locator" 
+  KCP_NS_NAME="$(kubectl get ns -l internal.workload.kcp.dev/cluster -o json \
+    | jq -r '.items[].metadata | select(.annotations."kcp.dev/namespace-locator"
     | contains("\"namespace\":\"default\"")) | .name'
   )"
+
+  if [ -z "$KCP_NS_NAME" ]; then
+    echo "[ERROR] Could not retrieve KCP_NS_NAME"
+    exit 1
+  fi
   echo "$KCP_NS_NAME"
 }
 


### PR DESCRIPTION
A change in kcp broke the function retrieving the namespace
on the compute cluster. This change fixes the issue and
adds a test to ensure that the scripts fails nicely if the
issue was to happen again.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>