### PR TITLE
Check for local binaries

### DIFF
--- a/ckcp/openshift_dev_setup.sh
+++ b/ckcp/openshift_dev_setup.sh
@@ -81,8 +81,6 @@ precheck_binary() {
 }
 
 init() {
-  precheck_binary "kubectl" "yq" "curl"
-
   APP_LIST=(
             "openshift-gitops"
             "cert-manager"
@@ -384,6 +382,7 @@ check_cr_sync() {
 
 main() {
   parse_args "$@"
+  precheck_binary "kubectl" "yq" "curl" "argocd"
   init
   precheck
   check_cluster_role

--- a/ckcp/openshift_dev_setup.sh
+++ b/ckcp/openshift_dev_setup.sh
@@ -70,7 +70,19 @@ parse_args() {
   done
 }
 
+# Checks if a binary is present on the local system
+precheck_binary() {
+  for binary in "$@"; do
+    command -v "$binary" >/dev/null 2>&1 || {
+      echo >&2 "openshift_dev_setup.sh requires '$binary' command-line utility to be installed on your local machine. Aborting..."
+      exit 1
+    }
+  done
+}
+
 init() {
+  precheck_binary "kubectl" "yq" "curl"
+
   APP_LIST=(
             "openshift-gitops"
             "cert-manager"


### PR DESCRIPTION
Make sure to check for binaries used by the script, beforehand, if it's not present fail as early as possible. For example in our case we didn't know `yq` is supposed to be part of the container image:

e.g. https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/31857/rehearse-31857-pull-ci-redhat-appstudio-managed-gitops-main-managed-gitops-e2e-tests-on-kcp/1565006131774885888#1:build-log.txt%3A37