### PR TITLE
Improve ckcp deployment to avoid cert-manger error

### DIFF
--- a/images/cluster-setup/Dockerfile
+++ b/images/cluster-setup/Dockerfile
@@ -22,7 +22,8 @@ RUN KUBE_VERSION=v1.24.0 && \
     curl -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/amd64/kubectl" && \
     chmod 755 /usr/local/bin/kubectl
 RUN microdnf install -y findutils-4.6.0 git-2.31.1 && microdnf clean all
-COPY ./install.sh /usr/local/bin/install.sh
+COPY bin /usr/local/bin
+RUN chmod 755 /usr/local/bin/install.sh /usr/local/bin/utils.sh
 USER 65532:65532
 VOLUME /workspace
 WORKDIR /workspace

--- a/images/cluster-setup/bin/utils.sh
+++ b/images/cluster-setup/bin/utils.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Pipeline Service Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exit_error() {
+  printf "\n[ERROR] %s\n" "$@" >&2
+  printf "Exiting script.\n"
+  exit 1
+}
+
+check_deployments() {
+  local ns="$1"
+  shift
+  local deployments=("$@")
+
+  for deploy in "${deployments[@]}"; do
+    printf "    - %s: " "$deploy"
+
+    #a loop to check if the deployment exists
+    if ! timeout 300s bash -c "while ! kubectl get deployment/$deploy -n $ns >/dev/null 2>/dev/null; do printf '.'; sleep 10; done"; then
+      printf "%s not found (timeout)\n" "$deploy"
+      kubectl get deployment/"$deploy" -n "$ns"
+      exit 1
+    else
+      printf "Exists"
+    fi
+
+    #a loop to check if the deployment is Available and Ready
+    if kubectl wait --for=condition=Available=true "deployment/$deploy" -n "$ns" --timeout=100s >/dev/null; then
+      printf ", Ready\n"
+    else
+      kubectl -n "$ns" describe "deployment/$deploy"
+      kubectl -n "$ns" logs "deployment/$deploy"
+      exit 1
+    fi
+  done
+}


### PR DESCRIPTION
**Purpose**

When you first install cert-manager, it will take a few seconds before the cert-manager API is usable. This change is to improve ckcp deployment to avoid the issue that the cert-manager API is usable while deploying ckcp.

**Changes**
1. Added a retry loop to ensure ckcp resources are deployed to OCP successfully
2. Minor changes to print out error messages when it fails
3. Update `check_cert_manager` function to reuse `check_deployments` function for validating cert manger deployment