### PR TITLE
fix tektonconfig sync

### DIFF
--- a/gitops/argocd/tektoncd/kustomization.yaml
+++ b/gitops/argocd/tektoncd/kustomization.yaml
@@ -4,7 +4,4 @@ kind: Kustomization
 resources:
   - allow-argocd-to-manage.yaml
   - openshift-operator.yaml
-  # This is breaking the installation.
-  # Commented out for stopping the bleeding
-  # till it gets fixed
-  #  - tekton-config.yaml
+  - tekton-config.yaml

--- a/gitops/argocd/tektoncd/tekton-config.yaml
+++ b/gitops/argocd/tektoncd/tekton-config.yaml
@@ -4,10 +4,9 @@ kind: TektonConfig
 metadata:
   name: config
   annotations:
-    # An Argo CD wave annotation ensures that some resources are always ready
-    # before next step. By default everything is a part of wave "0".
-    # Refer <https://argo-cd.readthedocs.io/en/release-1.8/user-guide/sync-waves/>
-    argocd.argoproj.io/sync-wave: "1"
+    # This Argo CD annotation ensures that Argo CD will skip the dry if the resource is not yet known to the cluster,
+    # the CRD will be applied and the resource can be created once the required dependencies are met.
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   profile: all
   targetNamespace: openshift-pipelines
@@ -17,8 +16,15 @@ spec:
     resources:
       # Only prune taskruns until re-reconciling of resources is fixed.
       - taskrun
+    keep: 100
+    # Note: `keep-since` and `keep` options are not available simultaniously to us.
+    # Upcoming versions of Openshift-Pipelines will have this option.
+    # Follow the PR - https://github.com/tektoncd/operator/pull/1025
+    # Since tekton-config resources are additive, adding `keep-since` here, would conflict with the `keep`
+    # which comes with default configurations when Openshift-Pipelines is deployed.
+    # To Do: Use `keep-since` option
     # Retain resources younger than 2 days (2880 mins)
-    keep-since: 2880
+    # keep-since: 2880
     # Run the TaskRun pruner every day at 0800 Hrs (8:00 AM) system time.
     # Refer <https://en.wikipedia.org/wiki/Cron> for detailed Cron format.
     schedule: "0 8 * * *"


### PR DESCRIPTION
This PR will allow the Argo CD to skip the verification of `tektonconfig` resource which is not available on the server before Openshift-Pipelines operator is deployed, else it would always end in error - `the server could not find the requested resource`.

Jira - [629](https://issues.redhat.com/projects/PLNSRVCE/issues/PLNSRVCE-629?filter=allopenissues)

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>