### PR TITLE
Fix handling of PARAMS in local/kcp/start.sh

### DIFF
--- a/local/kcp/start.sh
+++ b/local/kcp/start.sh
@@ -116,14 +116,8 @@ setupTraps
 KCP_PIDS=()
 KCP_CIDS=()
 
-PARAMS="${PARAMS:-}"
-if [[ -z "${PARAMS}" ]]; then
-  PARAMS=(
-    --token-auth-file "${PARENT_PATH}/kcp-tokens"
-    --profiler-address localhost:6060
-    -v 2
-  )
-fi
+PARAMS="${PARAMS:-"--token-auth-file ${PARENT_PATH}/kcp-tokens --profiler-address localhost:6060 -v 2"}"
+mapfile -d ' ' -t PARAMS < <(echo -n "$PARAMS")
 
 kcp-start
 printf "KUBECONFIG=%s\n" "${KUBECONFIG}"


### PR DESCRIPTION
PARAMS was not tokenized properly when passed through an environment variable.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>