### PR TITLE
Improve UX of local/kcp/start.sh

### DIFF
--- a/local/kcp/start.sh
+++ b/local/kcp/start.sh
@@ -36,8 +36,12 @@ precheck() {
 KCP_DIR="${KCP_DIR:-}"
 kcp-binaries() {
   if [[ -z "${KCP_DIR}" ]]; then
+    KCP_DIR="$(mktemp -d -t kcp.XXXXXXXXX)/kcp"
+  fi
+  if [[ ! -d "$KCP_DIR" ]]; then
     precheck git
-    KCP_PARENT_DIR="$(mktemp -d -t kcp.XXXXXXXXX)"
+    KCP_PARENT_DIR="$(cd "$(dirname "$KCP_DIR")" >/dev/null; pwd)"
+    mkdir -p "${KCP_PARENT_DIR}"
     pushd "${KCP_PARENT_DIR}"
     git clone https://github.com/kcp-dev/kcp.git
     KCP_DIR="${KCP_PARENT_DIR}/kcp"
@@ -48,6 +52,7 @@ kcp-binaries() {
     popd
     popd
   fi
+  KCP_DIR="$(cd "$KCP_DIR" >/dev/null; pwd)"
 }
 
 kcp-start() {


### PR DESCRIPTION
* Allow KCP_DIR to be a relative path
* Checkout and build kcp if KCP_DIR is specified but empty

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>

Example of a command solved by this PR: `rm -rf ./work; KCP_DIR=./work/kcp ./start.sh`