### PR TITLE
Sync TaskRuns, not Runs

### DIFF
--- a/ckcp/README.md
+++ b/ckcp/README.md
@@ -93,7 +93,7 @@ locations                                      scheduling.kcp.dev/v1alpha1      
 placements                                     scheduling.kcp.dev/v1alpha1            false        Placement
 <br>pipelineruns                      pr,prs       tekton.dev/v1beta1                     true         PipelineRun</br>
 <br>pipelines                                      tekton.dev/v1beta1                     true         Pipeline</br>
-<br>runs                                           tekton.dev/v1alpha1                    true         Run</br>
+<br>taskruns                                       tekton.dev/v1alpha1                    true         TaskRun</br>
 <br>tasks                                          tekton.dev/v1beta1                     true         Task</br>
 clusterworkspaces                              tenancy.kcp.dev/v1alpha1               false        ClusterWorkspace
 clusterworkspacetypes                          tenancy.kcp.dev/v1alpha1               false        ClusterWorkspaceType

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,8 +18,8 @@ cr_to_sync:
   - ingresses.networking.k8s.io
   - pipelines.tekton.dev
   - pipelineruns.tekton.dev
-  - runs.tekton.dev
   - tasks.tekton.dev
+  - taskruns.tekton.dev
   - networkpolicies.networking.k8s.io
 
 # Applications to be deployed on the cluster

--- a/images/kcp-registrar/register.sh
+++ b/images/kcp-registrar/register.sh
@@ -212,7 +212,7 @@ register() {
             sync_target_name="$(get_sync_target_name "${clusters[$i]}")"
             KUBECONFIG="${kcp_kcfg}" kubectl kcp workload sync "${sync_target_name}" \
                 --syncer-image "ghcr.io/kcp-dev/kcp/syncer:$KCP_SYNC_TAG" \
-                --resources deployments.apps,services,ingresses.networking.k8s.io,pipelines.tekton.dev,pipelineruns.tekton.dev,tasks.tekton.dev,runs.tekton.dev,networkpolicies.networking.k8s.io \
+                --resources deployments.apps,services,ingresses.networking.k8s.io,pipelines.tekton.dev,pipelineruns.tekton.dev,tasks.tekton.dev,taskruns.tekton.dev,networkpolicies.networking.k8s.io \
                 --output-file "$syncer_manifest"
             KUBECONFIG="${WORKSPACE_DIR}/credentials/kubeconfig/compute/${kubeconfigs[$i]}" kubectl apply \
                 --context "${contexts[$i]}" -f "$syncer_manifest"


### PR DESCRIPTION
TaskRun is to a Task what PipelineRun is to a Pipeline [0]. A Run resource is used to execute a CustomTask[1].

We may want Run resources in the future, but for now, let's stick with the basic Tekton resources.

[0] https://tekton.dev/docs/pipelines/taskruns
[1] https://tekton.dev/docs/pipelines/runs/

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>