### PR TITLE
Improve readability of ckcp script output via a better indentation

### DIFF
--- a/images/access-setup/content/bin/common.sh
+++ b/images/access-setup/content/bin/common.sh
@@ -65,3 +65,7 @@ get_context() {
   KUBECONFIG="$target" kubectl config view --flatten --minify >"$target.new"
   mv "$target.new" "$target"
 }
+
+function indent () {
+        sed "s/^/$(printf "%$1s")/"
+}

--- a/images/access-setup/content/bin/setup_kcp.sh
+++ b/images/access-setup/content/bin/setup_kcp.sh
@@ -140,19 +140,19 @@ generate_kcp_credentials() {
   printf "[KCP: %s]\n" "$kcp_name"
   kubeconfig="$credentials_dir/kcp/$kcp_name.kubeconfig"
 
-  printf "    - Create workspace:\n"
-  kubectl kcp workspace use "$KCP_ORG"
+  printf -- "- Create workspace:\n"
+  kubectl kcp workspace use "$KCP_ORG" | indent 4
   if ! kubectl kcp workspace use "$KCP_WORKSPACE" >/dev/null 2>&1; then
     kubectl kcp workspace create "$KCP_WORKSPACE" --type=universal --enter >/dev/null
   fi
-  kubectl kcp workspace current
+  kubectl kcp workspace current | indent 4
 
-  printf "    - Create service account:\n"
-  kubectl apply -k "$KUSTOMIZATION"
+  printf -- "- Create service account:\n"
+  kubectl apply -k "$KUSTOMIZATION" | indent 4
 
-  printf "    - Generate kubeconfig: "
+  printf -- "- Generate kubeconfig:\n"
   get_context "pac-manager" "pipelines-as-code" "pac-manager" "$kubeconfig"
-  printf "%s\n" "$kubeconfig"
+  printf "KUBECONFIG=%s\n" "$kubeconfig" | indent 4
 }
 
 main() {

--- a/images/cluster-setup/bin/utils.sh
+++ b/images/cluster-setup/bin/utils.sh
@@ -26,7 +26,7 @@ check_deployments() {
   local deployments=("$@")
 
   for deploy in "${deployments[@]}"; do
-    printf "    - %s: " "$deploy"
+    printf -- "- %s: " "$deploy"
 
     #a loop to check if the deployment exists
     if ! timeout 300s bash -c "while ! kubectl get deployment/$deploy -n $ns >/dev/null 2>/dev/null; do printf '.'; sleep 10; done"; then
@@ -46,4 +46,8 @@ check_deployments() {
       exit 1
     fi
   done
+}
+
+function indent () {
+        sed "s/^/$(printf "%$1s")/"
 }


### PR DESCRIPTION
Improving ckcp output readability from:
```
➜ /repos/plnsvc/pipelines-service % git:(main) ./ckcp/openshift_dev_setup.sh
Working directory: /tmp/tmp.xAXTA5oppU
[openshift-gitops]
  - OpenShift-GitOps: OK
  - Argo CD dashboard: ..........................................OK
  - Argo CD URL: https://openshift-gitops-server-openshift-gitops.apps.ci-ln-6114gpt-76ef8.origin-ci-int-aws.dev.rhcloud.com
  - Argo CD Login: OK
  - Register host cluster to ArgoCD as 'plnsvc':
INFO[0000] ServiceAccount "argocd-manager" created in namespace "kube-system"
INFO[0000] ClusterRole "argocd-manager-role" created
INFO[0001] ClusterRoleBinding "argocd-manager-role-binding" created
    OK

[cert-manager]
  - OpenShift-Cert-Manager:
    - cert-manager: ....Exists, Ready
    - cert-manager-cainjector: Exists, Ready
    - cert-manager-webhook: Exists, Ready

[ckcp]
  - kcp v0.8.2: OK
  - Route: OK
Current workspace is "root:default" (type "root:organization").
  - Setup kcp access:
[KCP: ckcp-ckcp.default.pipeline-service-compute]
    - Create workspace:
Current workspace is "root:default".
Current workspace is "root:default:pipeline-service-compute".
    - Create service account:
namespace/pipelines-as-code created
serviceaccount/pac-manager created
clusterrole.rbac.authorization.k8s.io/pac-admin created
clusterrolebinding.rbac.authorization.k8s.io/pac-manager-binding created
    - Generate kubeconfig: /tmp/tmp.xAXTA5oppU/credentials/kubeconfig/kcp/ckcp-ckcp.default.pipeline-service-compute.kubeconfig

[pipeline_service]
  - Setup compute access:
[Shared manifests]
    - tekton-chains signing key:
Private key written to cosign.key
Public key written to cosign.pub
OK
[Compute cluster: ci-ln-6114gpt-76ef8]
    - Create ServiceAccount for Pipelines as Code:
namespace/pipelines-as-code created
serviceaccount/pac-manager created
clusterrole.rbac.authorization.k8s.io/pac-admin created
clusterrolebinding.rbac.authorization.k8s.io/pac-manager-binding created
    - Generate kubeconfig: /tmp/tmp.xAXTA5oppU/credentials/kubeconfig/compute/ci-ln-6114gpt-76ef8.kubeconfig
    - Generate kustomization.yaml: /tmp/tmp.xAXTA5oppU/environment/compute/ci-ln-6114gpt-76ef8/kustomization.yaml
  - Deploy compute:
Extracting files under the kubeconfig dir and reading the content in each file
  - /tmp/tmp.xAXTA5oppU/credentials/kubeconfig/compute/ci-ln-6114gpt-76ef8.kubeconfig
    - ci-ln-6114gpt-76ef8 --- pac-manager --- /tmp/tmp.xAXTA5oppU/credentials/kubeconfig/compute/ci-ln-6114gpt-76ef8.kubeconfig

    - ci-ln-6114gpt-76ef8:
      - Installing shared manifests...
namespace/tekton-chains created
secret/signing-secrets created
      - Installing applications via Openshift GitOps...
application.argoproj.io/pipeline-service created
Checking deployment status
  - ci-ln-6114gpt-76ef8:
    - tekton-pipelines-controller: .....Exists, Ready
    - tekton-triggers-controller: ....Exists, Ready
    - tekton-triggers-core-interceptors: .Exists, Ready
    - tekton-chains-controller: Exists, Ready
    - cert-manager: Exists, Ready
    - cert-manager-cainjector: Exists, Ready
    - cert-manager-webhook: Exists, Ready
  - Install Pipelines as Code:
Installing Pipelines as Code
Temporary directory created: /tmp/pac-pipeline-service.oyqDjWmcx
Waiting for resources: OK
namespace/ci-runner created
secret/gitops-webhook-config created
repository.pipelinesascode.tekton.dev/gitops-repo created
Pipelines as Code installed

  - Register compute to KCP
Workspace: root:default:pipeline-service-compute
Registering clusters to kcp
- ci-ln-6114gpt-76ef8 (1/1)
Creating synctarget "ci-ln-6114gpt-76ef8"
Creating service account "kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy"
Creating cluster role "kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy" to give service account "kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy"

 1. write and sync access to the synctarget "kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy"
 2. write access to apiresourceimports.

Creating or updating cluster role binding "kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy" to bind service account "kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy" to cluster role "kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy".

Wrote physical cluster manifest to /tmp/syncer-ci-ln-6114gpt-76ef8.yaml for namespace "kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy". Use

  KUBECONFIG=<pcluster-config> kubectl apply -f "/tmp/syncer-ci-ln-6114gpt-76ef8.yaml"

to apply it. Use

  KUBECONFIG=<pcluster-config> kubectl get deployment -n "kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy" kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy

to verify the syncer pod is running.
depth=0 O = redhat
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 O = redhat
verify error:num=21:unable to verify the first certificate
verify return:1
depth=0 O = redhat
verify return:1
DONE
namespace/kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy created
serviceaccount/kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy created
secret/kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy-token created
clusterrole.rbac.authorization.k8s.io/kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy created
clusterrolebinding.rbac.authorization.k8s.io/kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy created
secret/kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy created
deployment.apps/kcp-syncer-ci-ln-6114gpt-76ef8-31fsrppy created
Configuring KCP workspace
clusterrole.rbac.authorization.k8s.io/apibinding:kubernetes created
clusterrolebinding.rbac.authorization.k8s.io/apibinding:kubernetes:all-users created
  - Sync CRDs to KCP: .OK
```

**To the following:**

```
➜ /repos/plnsvc/pipelines-service % git:(optim/ckcp-output) ./ckcp/openshift_dev_setup.sh
Working directory: /tmp/tmp.mMH2rTOL8E                                           
[openshift-gitops]
  - OpenShift-GitOps: OK
  - Argo CD dashboard: ..............................OK
  - Argo CD URL: https://openshift-gitops-server-openshift-gitops.apps.ci-ln-v7md5t2-76ef8.origin-ci-int-aws.dev.rhcloud.com
  - Argo CD Login: OK
  - Register host cluster to ArgoCD as 'plnsvc': 
INFO[0000] ServiceAccount "argocd-manager" created in namespace "kube-system" 
INFO[0000] ClusterRole "argocd-manager-role" created    
INFO[0001] ClusterRoleBinding "argocd-manager-role-binding" created 
    OK

[cert-manager]
  - OpenShift-Cert-Manager: 
    - cert-manager: ....Exists, Ready
    - cert-manager-cainjector: Exists, Ready
    - cert-manager-webhook: Exists, Ready

[ckcp]
  - kcp v0.8.2: OK
  - Route: OK
  - Setup kcp access:
    [KCP: ckcp-ckcp.default.pipeline-service-compute]
    - Create workspace:
        Current workspace is "root:default".
        Current workspace is "root:default:pipeline-service-compute".
    - Create service account:
        namespace/pipelines-as-code created
        serviceaccount/pac-manager created
        clusterrole.rbac.authorization.k8s.io/pac-admin created
        clusterrolebinding.rbac.authorization.k8s.io/pac-manager-binding created
    - Generate kubeconfig:
        KUBECONFIG=/tmp/tmp.mMH2rTOL8E/credentials/kubeconfig/kcp/ckcp-ckcp.default.pipeline-service-compute.kubeconfig

[pipeline_service]
  - Setup compute access:
    - Generating shared manifests:
      - tekton-chains manifest:
        Private key written to cosign.key
        Public key written to cosign.pub
        OK
    [Compute: ci-ln-v7md5t2-76ef8]
    - Create ServiceAccount for Pipelines as Code:
        namespace/pipelines-as-code created
        serviceaccount/pac-manager created
        clusterrole.rbac.authorization.k8s.io/pac-admin created
        clusterrolebinding.rbac.authorization.k8s.io/pac-manager-binding created
    - Generate kubeconfig:
        KUBECONFIG=/tmp/tmp.mMH2rTOL8E/credentials/kubeconfig/compute/ci-ln-v7md5t2-76ef8.kubeconfig
        - Generate kustomization.yaml: /tmp/tmp.mMH2rTOL8E/environment/compute/ci-ln-v7md5t2-76ef8/kustomization.yaml
  - Deploy compute:
    [Compute ci-ln-v7md5t2-76ef8]:
    - Installing shared manifests... 
        namespace/tekton-chains created
        secret/signing-secrets created
    - Installing applications via Openshift GitOps... 
        application.argoproj.io/pipeline-service created
    - Checking deployment status
        - tekton-pipelines-controller: ......Exists, Ready
        - tekton-triggers-controller: ...Exists, Ready
        - tekton-triggers-core-interceptors: Exists, Ready
        - tekton-chains-controller: Exists, Ready
        - cert-manager: Exists, Ready
        - cert-manager-cainjector: Exists, Ready
        - cert-manager-webhook: Exists, Ready
  - Install Pipelines as Code:
      Installing Pipelines as Code
      Temporary directory created: /tmp/pac-pipeline-service.A0KlhedHu
      Waiting for resources: .OK
      namespace/ci-runner created
      secret/gitops-webhook-config created
      repository.pipelinesascode.tekton.dev/gitops-repo created
      Pipelines as Code installed

[sync]
- Register compute to KCP
    Workspace: root:default:pipeline-service-compute
    Registering clusters to kcp
    - ci-ln-v7md5t2-76ef8 (1/1)
      Creating synctarget "ci-ln-v7md5t2-76ef8"
      Creating service account "kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8"
      Creating cluster role "kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8" to give service account "kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8"
      
       1. write and sync access to the synctarget "kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8"
       2. write access to apiresourceimports.
      
      Creating or updating cluster role binding "kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8" to bind service account "kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8" to cluster role "kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8".
      
      Wrote physical cluster manifest to /tmp/syncer-ci-ln-v7md5t2-76ef8.yaml for namespace "kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8". Use
      
        KUBECONFIG=<pcluster-config> kubectl apply -f "/tmp/syncer-ci-ln-v7md5t2-76ef8.yaml"
      
      to apply it. Use
      
        KUBECONFIG=<pcluster-config> kubectl get deployment -n "kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8" kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8
      
      to verify the syncer pod is running.
      namespace/kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8 created
      serviceaccount/kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8 created
      secret/kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8-token created
      clusterrole.rbac.authorization.k8s.io/kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8 created
      clusterrolebinding.rbac.authorization.k8s.io/kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8 created
      secret/kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8 created
      deployment.apps/kcp-syncer-ci-ln-v7md5t2-76ef8-1fp1sms8 created
    Configuring KCP workspace
      clusterrole.rbac.authorization.k8s.io/apibinding:kubernetes created
      clusterrolebinding.rbac.authorization.k8s.io/apibinding:kubernetes:all-users created
- Sync CRDs to KCP:.OK
```