### PR TITLE
fix issue with yq in setup_compute script

### DIFF
--- a/images/access-setup/content/bin/setup_compute.sh
+++ b/images/access-setup/content/bin/setup_compute.sh
@@ -166,7 +166,7 @@ generate_shared_manifests(){
         yq "sort_keys(.)"
     } > "$manifest"
     rm -rf "$manifests_tmp_dir"
-    if [ "$(yq ".data" "$manifest" | grep -cE "^cosign.key:|^cosign.password:|^cosign.pub:")" != "3" ]; then
+    if [ "$(yq ".data" < "$manifest" | grep -cE "^cosign.key:|^cosign.password:|^cosign.pub:")" != "3" ]; then
       printf "[ERROR] Invalid manifest: '%s'" "$manifest" >&2
       exit 1
     fi


### PR DESCRIPTION
Similar to this [PR](https://github.com/openshift-pipelines/pipeline-service/pull/162), it will fix - yq can't access root file system when installed via snap for `setup_compute.sh`

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>