### PR TITLE
Provide CRs to sync as parameter in register script

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,8 +11,8 @@ git_url: https://github.com/openshift-pipelines/pipeline-service.git
 # git_ref refers to the git repo's ref to be considered as the source of truth for Argo CD applications.
 git_ref: main
 
-# cr_to_sync is a list of the CRs which need to be synced.
-cr_to_sync:
+# crs_to_sync is a list of the CRs which need to be synced.
+crs_to_sync:
   - deployments.apps
   - services
   - ingresses.networking.k8s.io


### PR DESCRIPTION
Custom resources to sync with kcp can now be provided as a parameter for register.sh script.
Also CR_TO_SYNC was renamed to CRS_TO_SYNC since we are dealing with multiple CRs