### PR TITLE
Move to OpenShift Pipelines 1.8.

### DIFF
--- a/gitops/argocd/tektoncd/openshift-operator.yaml
+++ b/gitops/argocd/tektoncd/openshift-operator.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-pipelines-operator
   namespace: openshift-operators
 spec:
-  channel: pipelines-1.7
+  channel: pipelines-1.8
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
 It comes with PaC support for GitHub webhooks

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>