### PR TITLE
WIP: Openshift 4.11 Pod security standards

### DIFF
--- a/gitops/argocd/tektoncd/clusterrole.yaml
+++ b/gitops/argocd/tektoncd/clusterrole.yaml
@@ -1,0 +1,14 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipelines-scc-clusterrole
+rules:
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - pipelines-scc-v2

--- a/gitops/argocd/tektoncd/kustomization.yaml
+++ b/gitops/argocd/tektoncd/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - allow-argocd-to-manage.yaml
   - openshift-operator.yaml
   - tekton-config.yaml
+  - clusterrole.yaml
+  - pipelines-scc-v2.yaml

--- a/gitops/argocd/tektoncd/pipelines-scc-v2.yaml
+++ b/gitops/argocd/tektoncd/pipelines-scc-v2.yaml
@@ -1,0 +1,45 @@
+---
+allowHostPorts: false
+priority: 10
+requiredDropCapabilities:
+  - MKNOD
+allowPrivilegedContainer: false
+runAsUser:
+  type: RunAsAny
+users: []
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+seLinuxContext:
+  type: MustRunAs
+readOnlyRootFilesystem: false
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: 'true'
+    include.release.openshift.io/self-managed-high-availability: 'true'
+    include.release.openshift.io/single-node-developer: 'true'
+    kubernetes.io/description: >-
+      pipelines-scc-v2 is a close replica of pipelines-scc scc. pipelines-scc-v2 has allowPrivilegeEscalation=false.
+    release.openshift.io/create-only: 'true'
+  generation: 1
+  name: pipelines-scc-v2
+fsGroup:
+  type: MustRunAs
+groups:
+  - 'system:cluster-admins'
+kind: SecurityContextConstraints
+defaultAddCapabilities: null
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+allowHostPID: false
+allowHostNetwork: false
+allowPrivilegeEscalation: false
+apiVersion: security.openshift.io/v1
+allowedCapabilities:
+  - SETFCAP


### PR DESCRIPTION
Created new SCC to match baseline pod security standards by setting allowPrivilegeEscalation: false and updating clusterrole to use new SCC. This is required from Openshift 4.11 onwards. 