### PR TITLE
PLNSRVCE-671 : Automate the process to upgrade pipeline-service on staging cluster

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -68,7 +68,9 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Print image url
         if: steps.filter.outputs.access-setup == 'true'
-        run: echo "Image pushed to ${{ steps.push-to-quay-access-setup.outputs.registry-paths }}"
+        run: |
+          echo "Image pushed to ${{ steps.push-to-quay-access-setup.outputs.registry-paths }}"
+          echo "::set-output name=access_setup_pushed::true"
 
       # Build and push cluster-setup image, tagged with latest and the commit SHA.
       - name: Build cluster-setup Image
@@ -93,7 +95,9 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Print image url
         if: steps.filter.outputs.cluster-setup == 'true'
-        run: echo "Image pushed to ${{ steps.push-to-quay-cluster-setup.outputs.registry-paths }}"
+        run: |
+          echo "Image pushed to ${{ steps.push-to-quay-cluster-setup.outputs.registry-paths }}"
+          echo "::set-output name=cluster_setup_pushed::true"
 
       # Build and push gateway-deployment image, tagged with latest and the commit SHA.
       - name: Build gateway-deployment Image
@@ -118,7 +122,9 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Print image url
         if: steps.filter.outputs.gateway-deployment == 'true'
-        run: echo "Image pushed to ${{ steps.push-to-quay-gateway-deployment.outputs.registry-paths }}"
+        run: |
+          echo "Image pushed to ${{ steps.push-to-quay-gateway-deployment.outputs.registry-paths }}"
+          echo "::set-output name=gateway_deployment_pushed::true"
 
       # Build and push kcp-registrar image, tagged with latest and the commit SHA.
       - name: Build kcp-registrar Image
@@ -145,7 +151,9 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Print image url
         if: steps.filter.outputs.kcp-registrar == 'true'
-        run: echo "Image pushed to ${{ steps.push-to-quay-kcp-registrar.outputs.registry-paths }}"
+        run: |
+          echo "Image pushed to ${{ steps.push-to-quay-kcp-registrar.outputs.registry-paths }}"
+          echo "::set-output name=kcp_registrar_pushed::true"
 
       # Build and push devenv image, tagged with the branch name and the commit SHA.
       - name: Build devenv Image
@@ -170,7 +178,9 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Print image url
         if: steps.filter.outputs.devenv == 'true'
-        run: echo "Image pushed to ${{ steps.push-to-quay-devenv.outputs.registry-paths }}"
+        run: |
+          echo "Image pushed to ${{ steps.push-to-quay-devenv.outputs.registry-paths }}"
+          echo "::set-output name=devenv_pushed::true"
 
       # Build and push shellcheck image, tagged with latest and the commit SHA.
       - name: Build shellcheck Image
@@ -195,7 +205,9 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Print image url
         if: steps.filter.outputs.shellcheck == 'true'
-        run: echo "Image pushed to ${{ steps.push-to-quay-shellcheck.outputs.registry-paths }}"
+        run: |
+          echo "Image pushed to ${{ steps.push-to-quay-shellcheck.outputs.registry-paths }}"
+          echo "::set-output name=shellcheck_pushed::true"
 
       # Build and push vulnerability-scan image, tagged with latest and the commit SHA.
       - name: Build vulnerability Image
@@ -220,4 +232,84 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Print image url
         if: steps.filter.outputs.vulnerability == 'true'
-        run: echo "Image pushed to ${{ steps.push-to-quay-vulnerability-scan.outputs.registry-paths }}"
+        run: |
+          echo "Image pushed to ${{ steps.push-to-quay-vulnerability-scan.outputs.registry-paths }}"
+          echo "::set-output name=vulnerability_scan_pushed::true"
+
+      # Tag images with the latest commit ID if they are not changed.
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-access-setup
+        if: steps.build-image-access-setup.outputs.access_setup_pushed != 'true'
+        env:
+          image: access-setup
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./images/quay-upload/image-upload.sh
+
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-cluster-setup
+        if: steps.build-image-cluster-setup.outputs.cluster_setup_pushed != 'true'
+        env:
+          image: cluster-setup
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./images/quay-upload/image-upload.sh
+
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-gateway-deployment
+        if: steps.build-image-gateway-deployment.outputs.gateway_deployment_pushed != 'true'
+        env:
+          image: gateway-deployment
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./images/quay-upload/image-upload.sh
+
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-kcp-registrar
+        if: steps.build-image-access-setup.outputs.kcp_registrar_pushed != 'true'
+        env:
+          image: kcp-registrar
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./images/quay-upload/image-upload.sh
+
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-devenv
+        if: steps.build-image-access-setup.outputs.devenv_pushed != 'true'
+        env:
+          image: devenv
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./images/quay-upload/image-upload.sh
+
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-shellcheck
+        if: steps.build-image-access-setup.outputs.shellcheck_pushed != 'true'
+        env:
+          image: shellcheck
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./images/quay-upload/image-upload.sh
+
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-vulnerability-scan
+        if: steps.build-image-vulnerability-scan.outputs.vulnerability_scan_pushed != 'true'
+        env:
+          image: vulnerability-scan
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./images/quay-upload/image-upload.sh

--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -34,6 +34,12 @@ jobs:
             kcp-registrar:
               - '.github/workflows/build-push-images.yaml'
               - 'images/kcp-registrar/**'
+            quay-upload:
+              - '.github/workflows/build-push-images.yaml'
+              - 'test/images/quay-upload/**'
+            update-pipeline-service:
+              - '.github/workflows/build-push-images.yaml'
+              - 'images/update-pipeline-service/**'
             devenv:
               - '.github/workflows/build-push-images.yaml'
               - 'config/dependencies.yaml'
@@ -70,7 +76,16 @@ jobs:
         if: steps.filter.outputs.access-setup == 'true'
         run: |
           echo "Image pushed to ${{ steps.push-to-quay-access-setup.outputs.registry-paths }}"
-          echo "::set-output name=access_setup_pushed::true"
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-access-setup
+        if: steps.filter.outputs.access-setup != 'true'
+        env:
+          image: access-setup
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./test/images/quay-upload/image-upload.sh
 
       # Build and push cluster-setup image, tagged with latest and the commit SHA.
       - name: Build cluster-setup Image
@@ -97,7 +112,16 @@ jobs:
         if: steps.filter.outputs.cluster-setup == 'true'
         run: |
           echo "Image pushed to ${{ steps.push-to-quay-cluster-setup.outputs.registry-paths }}"
-          echo "::set-output name=cluster_setup_pushed::true"
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-cluster-setup
+        if: steps.filter.outputs.cluster-setup != 'true'
+        env:
+          image: cluster-setup
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./test/images/quay-upload/image-upload.sh
 
       # Build and push gateway-deployment image, tagged with latest and the commit SHA.
       - name: Build gateway-deployment Image
@@ -124,7 +148,16 @@ jobs:
         if: steps.filter.outputs.gateway-deployment == 'true'
         run: |
           echo "Image pushed to ${{ steps.push-to-quay-gateway-deployment.outputs.registry-paths }}"
-          echo "::set-output name=gateway_deployment_pushed::true"
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-gateway-deployment
+        if: steps.filter.outputs.gateway-deployment != 'true'
+        env:
+          image: gateway-deployment
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          access_token: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./test/images/quay-upload/image-upload.sh
 
       # Build and push kcp-registrar image, tagged with latest and the commit SHA.
       - name: Build kcp-registrar Image
@@ -153,7 +186,88 @@ jobs:
         if: steps.filter.outputs.kcp-registrar == 'true'
         run: |
           echo "Image pushed to ${{ steps.push-to-quay-kcp-registrar.outputs.registry-paths }}"
-          echo "::set-output name=kcp_registrar_pushed::true"
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-kcp-registrar
+        if: steps.filter.outputs.kcp-registrar != 'true'
+        env:
+          image: kcp-registrar
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./test/images/quay-upload/image-upload.sh
+
+      # Build and push quay-upload image, tagged with latest and the commit SHA.
+      - name: Build quay-upload Image
+        id: build-image-quay-upload
+        if: steps.filter.outputs.quay-upload == 'true'
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: quay-upload
+          context: ./test/images/quay-upload
+          tags: latest ${{ steps.vars.outputs.sha_short }} ${{ github.ref_name }}
+          containerfiles: |
+            ./test/images/quay-upload/Dockerfile
+      - name: Push to quay.io
+        id: push-to-quay-quay-upload
+        if: steps.filter.outputs.quay-upload == 'true'
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image-quay-upload.outputs.image }}
+          tags: ${{ steps.build-image-quay-upload.outputs.tags }} ${{ github.ref_name }}
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Print image url
+        if: steps.filter.outputs.quay-upload == 'true'
+        run: |
+          echo "Image pushed to ${{ steps.push-to-quay-quay-upload.outputs.registry-paths }}"
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-quay-upload
+        if: steps.filter.outputs.quay-upload != 'true'
+        env:
+          image: quay-upload
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./test/images/quay-upload/image-upload.sh
+
+      # Build and push update-pipeline-service image, tagged with latest and the commit SHA.
+      - name: Build update-pipeline-service Image
+        id: build-image-update-pipeline-service
+        if: steps.filter.outputs.update-pipeline-service == 'true'
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: update-pipeline-service
+          context: ./images/update-pipeline-service
+          tags: latest ${{ steps.vars.outputs.sha_short }} ${{ github.ref_name }}
+          containerfiles: |
+            ./images/update-pipeline-service/Dockerfile
+      - name: Push to quay.io
+        id: push-to-quay-update-pipeline-service
+        if: steps.filter.outputs.update-pipeline-service == 'true'
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image-update-pipeline-service.outputs.image }}
+          tags: ${{ steps.build-image-update-pipeline-service.outputs.tags }} ${{ github.ref_name }}
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Print image url
+        if: steps.filter.outputs.update-pipeline-service == 'true'
+        run: |
+          echo "Image pushed to ${{ steps.push-to-quay-update-pipeline-service.outputs.registry-paths }}"
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-update-pipeline-service
+        if: steps.filter.outputs.update-pipeline-service != 'true'
+        env:
+          image: update-pipeline-service
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./test/images/quay-upload/image-upload.sh
 
       # Build and push devenv image, tagged with the branch name and the commit SHA.
       - name: Build devenv Image
@@ -180,7 +294,16 @@ jobs:
         if: steps.filter.outputs.devenv == 'true'
         run: |
           echo "Image pushed to ${{ steps.push-to-quay-devenv.outputs.registry-paths }}"
-          echo "::set-output name=devenv_pushed::true"
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-devenv
+        if: steps.filter.outputs.devenv != 'true'
+        env:
+          image: devenv
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./test/images/quay-upload/image-upload.sh
 
       # Build and push shellcheck image, tagged with latest and the commit SHA.
       - name: Build shellcheck Image
@@ -207,7 +330,16 @@ jobs:
         if: steps.filter.outputs.shellcheck == 'true'
         run: |
           echo "Image pushed to ${{ steps.push-to-quay-shellcheck.outputs.registry-paths }}"
-          echo "::set-output name=shellcheck_pushed::true"
+      - name: Tag latest commit ID to quay.io
+        id: tag-commit-quay-shellcheck
+        if: steps.filter.outputs.shellcheck != 'true'
+        env:
+          image: shellcheck
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          ./test/images/quay-upload/image-upload.sh
 
       # Build and push vulnerability-scan image, tagged with latest and the commit SHA.
       - name: Build vulnerability Image
@@ -234,82 +366,13 @@ jobs:
         if: steps.filter.outputs.vulnerability == 'true'
         run: |
           echo "Image pushed to ${{ steps.push-to-quay-vulnerability-scan.outputs.registry-paths }}"
-          echo "::set-output name=vulnerability_scan_pushed::true"
-
-      # Tag images with the latest commit ID if they are not changed.
-      - name: Tag latest commit ID to quay.io
-        id: tag-commit-quay-access-setup
-        if: steps.build-image-access-setup.outputs.access_setup_pushed != 'true'
-        env:
-          image: access-setup
-          registry: quay.io/redhat-pipeline-service
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-        run: |
-          ./images/quay-upload/image-upload.sh
-
-      - name: Tag latest commit ID to quay.io
-        id: tag-commit-quay-cluster-setup
-        if: steps.build-image-cluster-setup.outputs.cluster_setup_pushed != 'true'
-        env:
-          image: cluster-setup
-          registry: quay.io/redhat-pipeline-service
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-        run: |
-          ./images/quay-upload/image-upload.sh
-
-      - name: Tag latest commit ID to quay.io
-        id: tag-commit-quay-gateway-deployment
-        if: steps.build-image-gateway-deployment.outputs.gateway_deployment_pushed != 'true'
-        env:
-          image: gateway-deployment
-          registry: quay.io/redhat-pipeline-service
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-        run: |
-          ./images/quay-upload/image-upload.sh
-
-      - name: Tag latest commit ID to quay.io
-        id: tag-commit-quay-kcp-registrar
-        if: steps.build-image-access-setup.outputs.kcp_registrar_pushed != 'true'
-        env:
-          image: kcp-registrar
-          registry: quay.io/redhat-pipeline-service
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-        run: |
-          ./images/quay-upload/image-upload.sh
-
-      - name: Tag latest commit ID to quay.io
-        id: tag-commit-quay-devenv
-        if: steps.build-image-access-setup.outputs.devenv_pushed != 'true'
-        env:
-          image: devenv
-          registry: quay.io/redhat-pipeline-service
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-        run: |
-          ./images/quay-upload/image-upload.sh
-
-      - name: Tag latest commit ID to quay.io
-        id: tag-commit-quay-shellcheck
-        if: steps.build-image-access-setup.outputs.shellcheck_pushed != 'true'
-        env:
-          image: shellcheck
-          registry: quay.io/redhat-pipeline-service
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-        run: |
-          ./images/quay-upload/image-upload.sh
-
       - name: Tag latest commit ID to quay.io
         id: tag-commit-quay-vulnerability-scan
-        if: steps.build-image-vulnerability-scan.outputs.vulnerability_scan_pushed != 'true'
+        if: steps.filter.outputs.vulnerability != 'true'
         env:
           image: vulnerability-scan
           registry: quay.io/redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
         run: |
-          ./images/quay-upload/image-upload.sh
+          ./test/images/quay-upload/image-upload.sh

--- a/images/quay-upload/image-upload.sh
+++ b/images/quay-upload/image-upload.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Pipeline Service Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# fetching values from env vars
+username="$username"
+password="$password"
+registry="$registry"
+image="$image"
+image_path="$registry"/"$image"
+
+fetch_commits() {
+  for i in {1..3}; do
+    latest_commit_status=$(
+      curl -sw '%{http_code}' -o /tmp/latest_commit.json \
+      -H "Accept: application/vnd.github.VERSION.sha" \
+      "https://api.github.com/repos/openshift-pipelines/pipeline-service/commits/main"
+    )
+    if [[ "$latest_commit_status" == "200" ]]; then
+      latest_commit=$(cut -c -7 < /tmp/latest_commit.json)
+    else
+      if [[ "$i" -lt 3 ]]; then
+        printf "Unable to fetch the latest commit. Retrying...\n" >&2
+        sleep 20
+      else
+        printf "Error while fetching the latest commit from GitHub. Status code: %s\n" "${latest_commit_status}" >&2
+        exit 1
+      fi
+    fi
+  done
+}
+
+tag_and_push() {
+  podman login -u="$username" -p="$password" quay.io
+  podman pull -q "$image_path":latest
+  # verify that the image is actually pulled
+
+  image=$(podman images "$image_path":latest --format json | jq '.[0].Names')
+
+  if [[ "$image" == "null" ]]; then
+    printf "Image was not pulled due to some issue. Exiting.\n"
+    exit 1
+  else
+    printf "Image pull was successful.\n"
+  fi
+
+  podman tag "$image_path":latest "$image_path":"$latest_commit"
+  podman push "$image_path":"$latest_commit"
+}
+
+main() {
+  fetch_commits
+  tag_and_push
+}
+
+if [ "${BASH_SOURCE[0]}" == "$0" ]; then
+  main "$@"
+fi

--- a/images/update-pipeline-service/Dockerfile
+++ b/images/update-pipeline-service/Dockerfile
@@ -1,0 +1,32 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+LABEL build-date= \
+      com.redhat.build-host= \
+      description="This image provides the required tooling to update the image tags on the SRE gitops repository" \
+      distribution-scope="public" \
+      io.k8s.description="This image provides the required tooling to update the image tags on the SRE gitops repository" \
+      io.k8s.display-name="upgrade gitlab" \
+      maintainer="Pipeline Service" \
+      name="upgrade-gitlab" \
+      release="0.1" \
+      summary="Updates the image tags on the SRE gitops repository" \
+      url="" \
+      vcs-ref=  \
+      vcs-type="git" \
+      vendor="Pipeline Service" \
+      version="0.1"
+WORKDIR /
+RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
+ENV HOME /tmp/home
+RUN mkdir $HOME && chmod 777 $HOME && chown 65532:65532 $HOME
+RUN YQ_VERSION="v4.24.5" && \
+    curl --fail -sSL -o "/usr/local/bin/yq" "https://github.com/mikefarah/yq/releases/download/$YQ_VERSION/yq_linux_amd64" && \
+    chmod 755 "/usr/local/bin/yq"
+RUN JQ_VERSION="1.6" && \
+    curl -sSL -o "/usr/local/bin/jq" "https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64" && \
+    chmod 755 "/usr/local/bin/jq"
+COPY ./bin /usr/local/bin
+RUN chmod 755 /usr/local/bin/gitlab_open_mr.sh && chmod 755 /usr/local/bin/update.sh
+USER 65532:65532
+VOLUME /workspace
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/update.sh"]

--- a/images/update-pipeline-service/bin/gitlab_open_mr.sh
+++ b/images/update-pipeline-service/bin/gitlab_open_mr.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+raise_mr_gitlab() {
+  SOURCE_BRANCH="robot/pipeline-service-update"
+  GITLAB_TOKEN="${GITLAB_TOKEN}"
+  current_commit=$1
+  latest_commit=$2
+  if [[ "$current_commit" == "$latest_commit" ]]; then
+    printf "Latest images already available\n"
+    exit 0
+  fi
+  printf "Replacing the image tags with the latest commit sha and raising a MR\n"
+  sed -i "s/$current_commit/$latest_commit/g" ".gitlab-ci.yml"
+
+  for i in {1..3}; do
+    resp_http_code=$(curl -k -w '%{http_code}' -o /tmp/commit_logs.json -X PUT --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --header "Content-Type: application/json" --data '{"branch": "robot/pipeline-service-update", "commit_message": "Updating the image tag with the latest commit SHA", "content": '"$(jq -Rs '.' .gitlab-ci.yml)"'}' "https://gitlab.cee.redhat.com/api/v4/projects/$CI_PROJECT_ID/repository/files/.gitlab-ci.yml")
+    printf "%s\n" "$resp_http_code"
+    cat /tmp/commit_logs.json
+
+    if [[ "$resp_http_code" == "200" ]]; then
+      # raise a MR
+      BODY_MR="{
+          \"id\": \"${CI_PROJECT_ID}\",
+          \"source_branch\": \"${SOURCE_BRANCH}\",
+          \"target_branch\": \"main\",
+          \"title\": \"Update image tags with the latest commit\"
+      }";
+
+      printf "Check if a MR already exists\n"
+      existing_mr=$(curl -sk \
+      -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+      "https://gitlab.cee.redhat.com/api/v4/projects/$CI_PROJECT_ID/merge_requests?source_branch=$SOURCE_BRANCH&state=opened")
+
+      if [  "$(echo "$existing_mr" | jq '. | length')" == 0 ]; then
+        printf "Raising a new MR\n"
+        resp_http_code=$(curl -k -w '%{http_code}' -o /tmp/raise_pr.json \
+            -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-raw "${BODY_MR}" \
+            -X POST "https://gitlab.cee.redhat.com/api/v4/projects/$CI_PROJECT_ID/merge_requests")
+        if [[ "$resp_http_code" == "201" ]]; then
+          printf "MR successfully raised\n"
+          exit 0
+        else
+          printf "Unable to raise a new MR\n" >&2
+          exit 1
+        fi
+      else
+        printf "MR already exists. Pushed the latest tag to the same MR.\n"
+        exit 0
+      fi
+    return
+    else
+      if [[ "$i" -lt 3 ]]; then
+        printf "Unable to commit the file. Retrying...\n"
+        sleep 5
+      else
+        printf "Error while committing the file. Status code: %s\n" "${resp_http_code}" >&2
+        exit 1
+      fi
+    fi
+  done
+}

--- a/images/update-pipeline-service/bin/update.sh
+++ b/images/update-pipeline-service/bin/update.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+declare -r TARGET_BRANCH="main"
+declare -r gitlab_ci="./.gitlab-ci.yml"
+
+SCRIPT_DIR="$(
+  cd "$(dirname "$0")" >/dev/null
+  pwd
+)"
+
+# shellcheck source=images/update-pipeline-service/bin/gitlab_open_mr.sh
+source "$SCRIPT_DIR/gitlab_open_mr.sh"
+
+usage() {
+
+  printf "
+Usage:
+    %s [options]
+
+Fetch the latest commit from Pipeline Service Github repo
+and update the image tags in the Gitlab repo where the config lives.
+
+Optional arguments:
+    -scm, --source-control-management SCM
+        Source Code Management tools like github, gitlab, bitbucket etc.
+        Default: gitlab
+    -d, --debug
+        Activate tracing/debug mode.
+    -h, --help
+        Display this message.
+
+Example:
+    %s -scm gitlab
+" "${0##*/}" "${0##*/}" >&2
+}
+
+parse_args() {
+  SCM="gitlab"
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+    -scm | --source-code-management)
+      shift
+      SCM="$1"
+      ;;
+    -d | --debug)
+      set -x
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      usage
+      exit 1
+      ;;
+    esac
+    shift
+  done
+}
+
+fetch_commits() {
+  for i in {1..3}; do
+    latest_commit_status=$(
+      curl -sw '%{http_code}' -o /tmp/latest_commit.json \
+      -H "Accept: application/vnd.github.VERSION.sha" \
+      "https://api.github.com/repos/openshift-pipelines/pipeline-service/commits/$TARGET_BRANCH"
+    )
+    if [[ "$latest_commit_status" == "200" ]]; then
+      latest_commit=$(cut -c -7 < /tmp/latest_commit.json)
+    else
+      if [[ "$i" -lt 3 ]]; then
+        printf "Unable to fetch the latest commit. Retrying...\n"
+        sleep 20
+      else
+        printf "Error while fetching the latest commit from GitHub. Status code: %s\n" "${latest_commit_status}" >&2
+        exit 1
+      fi
+    fi
+  done
+  current_commit=$(yq '.build-job.image.name' < "$gitlab_ci" | cut -d ':' -f2)
+}
+
+main() {
+  parse_args "$@"
+  fetch_commits
+  if [[ $SCM == "gitlab" ]]; then
+    raise_mr_gitlab "$current_commit" "$latest_commit"
+  fi
+}
+
+if [ "${BASH_SOURCE[0]}" == "$0" ]; then
+  main "$@"
+fi

--- a/test/images/quay-upload/Dockerfile
+++ b/test/images/quay-upload/Dockerfile
@@ -1,0 +1,29 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+LABEL build-date= \
+      com.redhat.build-host= \
+      description="This image provides binaries and a script to tag images with the latest commit ID on quay.io" \
+      distribution-scope="public" \
+      io.k8s.description="This image provides binaries and a script to tag images with the latest commit ID on quay.io" \
+      io.k8s.display-name="quay-upload" \
+      maintainer="Pipeline Service" \
+      name="quay-upload" \
+      release="0.1" \
+      summary="Providea a script to tag images with the latest commit ID on quay.io" \
+      url="" \
+      vcs-ref=  \
+      vcs-type="git" \
+      vendor="Pipeline Service" \
+      version="0.1"
+WORKDIR /
+RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
+ENV HOME /tmp/home
+RUN mkdir $HOME && chmod 777 $HOME && chown 65532:65532 $HOME
+RUN JQ_VERSION="1.6" && \
+    curl -sSL -o "/usr/local/bin/jq" "https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64" && \
+    chmod 755 "/usr/local/bin/jq"
+COPY image-upload.sh /usr/local/bin/image-upload.sh
+RUN chmod 755 /usr/local/bin/image-upload.sh
+USER 65532:65532
+VOLUME /workspace
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/image-upload.sh"]


### PR DESCRIPTION
Context:
Gitlab CI uses cluster-setup and kcp-registrar images with 'latest' tag at the moment. We want to provide the latest commit SHA as the tags instead of latest. I am working on automating this process where we always fetch the last commit ID and provide that as the tag in Gitlab. Once this is merged, it will trigger a CI to update our staging cluster with the latest code.

Problem:
Now, the Github action build-push-images.yaml is based on path filtering. It would only build and create new images only when there are changes to that image content. Otherwise, it will just have a older commit tag as the latest. So there is a possibility of non-existent image tag which Gitlab will try to fetch and fail. 

Solution:
This PR that **does not** build a new image if there are no changes but **only tags** it with the latest commit ID.

Uploading images with latest tags to quay.io
- If the image has been built and pushed to quay, then it won't tag it again and push
- But if the image is not built, then this change will make sure that the image is tagged with the latest commit and push it to quay.

This goes along with the PR raised on Gitlab (this one needs to be merged first).
