### PR TITLE
Modify upgrade_kcp workflows

### DIFF
--- a/.github/workflows/kcp-upgrade.yaml
+++ b/.github/workflows/kcp-upgrade.yaml
@@ -17,15 +17,20 @@ jobs:
           ref: main
 
       - name: Check if a new kcp version exists and update the files if it does
+        id: fetch-kcp-version
         run: |
-          ./images/kcp-upgrade/upgrade.sh
+          sh ./images/kcp-upgrade/upgrade.sh
+          echo "::set-output name=NEW_KCP_VERSION::$(curl -s https://api.github.com/repos/kcp-dev/kcp/releases/latest | yq '.tag_name' | sed 's/v//')"
+          echo "::set-output name=NEW_KCP_VERSION_FOUND::true"
+        continue-on-error: true
 
-      - name: Create PR
+      - name: Create PR if a new kcp version exists
+        if: ${{ steps.fetch-kcp-version.outputs.NEW_KCP_VERSION_FOUND == 'true' }}
         id: create-pull-request
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.UPGRADE_TOKEN }}
-          commit-message: Upgrade kcp to the latest available version
+          commit-message: 'Upgrade kcp to the latest available version: ${{ steps.fetch-kcp-version.outputs.NEW_KCP_VERSION }}'
           branch: upgrade_kcp
           delete-branch: true
-          title: 'Upgrade kcp to the latest version'
+          title: 'Upgrade kcp to the latest version: ${{ steps.fetch-kcp-version.outputs.NEW_KCP_VERSION }}'

--- a/images/kcp-upgrade/upgrade.sh
+++ b/images/kcp-upgrade/upgrade.sh
@@ -22,12 +22,19 @@ SCRIPT_DIR="$(
   cd "$(dirname "$0")" >/dev/null
   pwd
 )"
+
 CONFIG="$(dirname "$(dirname "$SCRIPT_DIR")")/config/config.yaml"
 current_kcp_version="$(yq '.version.kcp' "$CONFIG" | sed 's/v//' )"
 
 latest_kcp_version="$(curl -s https://api.github.com/repos/kcp-dev/kcp/releases/latest | yq '.tag_name' | sed 's/v//' )"
 
-if [[ "$current_kcp_version" != "$latest_kcp_version" ]]; then
+if [ "$latest_kcp_version" == "" ] || [ "$current_kcp_version" == "" ]; then
+  printf "[ERROR] Could not retrieve kcp version: current='%s' latest='%s'" "${current_kcp_version:-not found}" "${latest_kcp_version:-not found}" >&2
+  exit 1
+fi
+
+if [ "$current_kcp_version" != "$latest_kcp_version" ]; then
+  printf "\nUpgrading kcp version from '%s' to '%s'\n"  "$current_kcp_version" "$latest_kcp_version"
   sed -i "s,$current_kcp_version,$latest_kcp_version,g" .github/workflows/build-push-images.yaml
   sed -i "s,$current_kcp_version,$latest_kcp_version,g" .github/workflows/local-dev-ci.yaml
   sed -i "s,$current_kcp_version,$latest_kcp_version,g" DEPENDENCIES.md
@@ -37,5 +44,6 @@ if [[ "$current_kcp_version" != "$latest_kcp_version" ]]; then
   sed -i "s,$current_kcp_version,$latest_kcp_version,g" images/kcp-registrar/register.sh
   sed -i "s,$current_kcp_version,$latest_kcp_version,g" config/config.yaml
 else
+  printf "\nNo new kcp version is found, already on latest version.\n"
   exit 1
 fi


### PR DESCRIPTION
Modify upgrade_kcp workflows
    - to not fail the workflows when the kcp version is already the
      latest one instead gracefully exit the workflow by skippng the
      next step.

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>