### PR TITLE
Fix kcp-upgrade workflow

### DIFF
--- a/.github/workflows/kcp-upgrade.yaml
+++ b/.github/workflows/kcp-upgrade.yaml
@@ -19,10 +19,11 @@ jobs:
       - name: Check if a new kcp version exists and update the files if it does
         id: fetch-kcp-version
         run: |
-          sh ./images/kcp-upgrade/upgrade.sh
-          echo "::set-output name=NEW_KCP_VERSION::$(curl -s https://api.github.com/repos/kcp-dev/kcp/releases/latest | yq '.tag_name' | sed 's/v//')"
-          echo "::set-output name=NEW_KCP_VERSION_FOUND::true"
-        continue-on-error: true
+          ./images/kcp-upgrade/upgrade.sh
+          if [ -e "/tmp/kcp-upgrade.txt" ]; then
+            echo "::set-output name=NEW_KCP_VERSION::$(cat "/tmp/kcp-upgrade.txt" | sed 's/v//')"
+            echo "::set-output name=NEW_KCP_VERSION_FOUND::true"
+          fi
 
       - name: Create PR if a new kcp version exists
         if: ${{ steps.fetch-kcp-version.outputs.NEW_KCP_VERSION_FOUND == 'true' }}

--- a/images/kcp-upgrade/upgrade.sh
+++ b/images/kcp-upgrade/upgrade.sh
@@ -44,7 +44,7 @@ if [ "$current_kcp_version" != "$latest_kcp_version" ]; then
   sed -i "s,$current_kcp_version,$latest_kcp_version,g" images/kcp-registrar/register.sh
   sed -i "s,$current_kcp_version,$latest_kcp_version,g" config/config.yaml
   sed -i "s,$current_kcp_version,$latest_kcp_version,g" config/dependencies.yaml
+  echo "$latest_kcp_version" > /tmp/kcp-upgrade.txt
 else
-  printf "\nNo new kcp version is found, already on latest version.\n"
-  exit 1
+  printf "\nAlready on the latest version: '%s'.\n" "$current_kcp_version"
 fi


### PR DESCRIPTION
The previous workflow would always be successful because it could not discriminate between the script failing and no update being required.

Changes have been implemented to have the workflow fail in case the script fails, and be successul if there's no update required.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>