### PR TITLE
Fix gitlab pipeline - Modify the name of the job used in Gitlab ci to fetch the current commit

### DIFF
--- a/images/update-pipeline-service/bin/gitlab_open_mr.sh
+++ b/images/update-pipeline-service/bin/gitlab_open_mr.sh
@@ -15,7 +15,6 @@ raise_mr_gitlab() {
   for i in {1..3}; do
     resp_http_code=$(curl -k -w '%{http_code}' -o /tmp/commit_logs.json -X PUT --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --header "Content-Type: application/json" --data '{"branch": "robot/pipeline-service-update", "commit_message": "Updating the image tag with the latest commit SHA", "content": '"$(jq -Rs '.' .gitlab-ci.yml)"'}' "https://gitlab.cee.redhat.com/api/v4/projects/$CI_PROJECT_ID/repository/files/.gitlab-ci.yml")
     printf "%s\n" "$resp_http_code"
-    cat /tmp/commit_logs.json
 
     if [[ "$resp_http_code" == "200" ]]; then
       # raise a MR

--- a/images/update-pipeline-service/bin/update.sh
+++ b/images/update-pipeline-service/bin/update.sh
@@ -82,7 +82,7 @@ fetch_commits() {
       fi
     fi
   done
-  current_commit=$(yq '.build-job.image.name' < "$gitlab_ci" | cut -d ':' -f2)
+  current_commit=$(yq '.deploy-job.image.name' < "$gitlab_ci" | cut -d ':' -f2)
 }
 
 main() {


### PR DESCRIPTION
Currently, Gitlab auto pr creation is failing due to incorrect job name given in the script that fetches the current commit ID. This fix fixes the name which fixes the issue with empty MR being opened.