### PR TITLE
Update Dockerfiles to use SHA instead of tags

### DIFF
--- a/exploration/argocd-external/images/argocd-registrar/Dockerfile
+++ b/exploration/argocd-external/images/argocd-registrar/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides binaries and a script to easily register clusters to Argo CD." \

--- a/images/access-setup/Dockerfile
+++ b/images/access-setup/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 WORKDIR /
 RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
 ENV HOME /tmp/home

--- a/images/cluster-setup/Dockerfile
+++ b/images/cluster-setup/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides binaries and a script to install tektoncd components on the workload clusters." \

--- a/images/gateway-deployment/Dockerfile
+++ b/images/gateway-deployment/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides binaries and a script to deploy the gateway component on kcp." \

--- a/images/kcp-registrar/Dockerfile
+++ b/images/kcp-registrar/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides binaries and a script to easily register clusters to kcp." \

--- a/images/update-pipeline-service/Dockerfile
+++ b/images/update-pipeline-service/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides the required tooling to update the image tags on the SRE gitops repository" \

--- a/test/images/devenv/Dockerfile
+++ b/test/images/devenv/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/podman/stable:v4
+#FROM quay.io/podman/stable:v4
+FROM quay.io/podman/stable@sha256:e6a491133007ce6e674fb656753fdc62664bf255b6985dec22ee162855ba509b
 
 RUN set -x \
     && mkdir ~/.kube \

--- a/test/images/quay-upload/Dockerfile
+++ b/test/images/quay-upload/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides binaries and a script to tag images with the latest commit ID on quay.io" \

--- a/test/images/shellcheck/Dockerfile
+++ b/test/images/shellcheck/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 LABEL build-date= \
     com.redhat.build-host= \
     description="This image provides shellcheck binary." \

--- a/test/images/vulnerability-scan/Dockerfile
+++ b/test/images/vulnerability-scan/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides a script to scan Clair for security vulnerabilities on container images via Quay." \


### PR DESCRIPTION
Using the SHA will enable us to trigger the rebuild of images when new images are made available, especially in the case when the new image solves a vulnerability issue.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>