### PR TITLE
Updated the registry value used while sending a GET API request on quay-upload/image-upload.sh

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -81,7 +81,7 @@ jobs:
         if: steps.filter.outputs.access-setup != 'true'
         env:
           image: access-setup
-          registry: quay.io/redhat-pipeline-service
+          registry: redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
         run: |
@@ -117,7 +117,7 @@ jobs:
         if: steps.filter.outputs.cluster-setup != 'true'
         env:
           image: cluster-setup
-          registry: quay.io/redhat-pipeline-service
+          registry: redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
         run: |
@@ -153,7 +153,7 @@ jobs:
         if: steps.filter.outputs.gateway-deployment != 'true'
         env:
           image: gateway-deployment
-          registry: quay.io/redhat-pipeline-service
+          registry: redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           access_token: ${{ secrets.QUAY_TOKEN }}
         run: |
@@ -191,7 +191,7 @@ jobs:
         if: steps.filter.outputs.kcp-registrar != 'true'
         env:
           image: kcp-registrar
-          registry: quay.io/redhat-pipeline-service
+          registry: redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
         run: |
@@ -227,7 +227,7 @@ jobs:
         if: steps.filter.outputs.quay-upload != 'true'
         env:
           image: quay-upload
-          registry: quay.io/redhat-pipeline-service
+          registry: redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
         run: |
@@ -263,7 +263,7 @@ jobs:
         if: steps.filter.outputs.update-pipeline-service != 'true'
         env:
           image: update-pipeline-service
-          registry: quay.io/redhat-pipeline-service
+          registry: redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
         run: |
@@ -299,7 +299,7 @@ jobs:
         if: steps.filter.outputs.devenv != 'true'
         env:
           image: devenv
-          registry: quay.io/redhat-pipeline-service
+          registry: redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
         run: |
@@ -335,7 +335,7 @@ jobs:
         if: steps.filter.outputs.shellcheck != 'true'
         env:
           image: shellcheck
-          registry: quay.io/redhat-pipeline-service
+          registry: redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
         run: |
@@ -371,7 +371,7 @@ jobs:
         if: steps.filter.outputs.vulnerability != 'true'
         env:
           image: vulnerability-scan
-          registry: quay.io/redhat-pipeline-service
+          registry: redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
         run: |


### PR DESCRIPTION
Github action to push images into quay is failing because a the URL sent during an API call is incorrect

URL : https://quay.io/api/v1/repository/$image_path/tag/
Current value of image_path : quay.io/redhat-pipeline-service/access-setup
This PR will change that to : redhat-pipeline-service/access-setup