### PR TITLE
Upgrade SHA for devenv image

### DIFF
--- a/test/images/devenv/Dockerfile
+++ b/test/images/devenv/Dockerfile
@@ -1,5 +1,5 @@
 #FROM quay.io/podman/stable:v4
-FROM quay.io/podman/stable@sha256:4235eac4abf82be8217a35dea93387e235bf181b297a6b165fbf90a438907fcb
+FROM quay.io/podman/stable@sha256:e968245017a54e31fec7583c589f1d68e5a14723e76d29861a887865c09084a0
 
 RUN set -x \
     && mkdir ~/.kube \


### PR DESCRIPTION
Signed-off-by: Romain Arnaud <rarnaud@redhat.com>

SHA tested with:

```
> skopeo inspect docker://quay.io/podman/stable:v4 | jq ".Digest" -r
sha256:e968245017a54e31fec7583c589f1d68e5a14723e76d29861a887865c09084a0

> podman pull quay.io/podman/stable@sha256:e968245017a54e31fec7583c589f1d68e5a14723e76d29861a887865c09084a0
Trying to pull quay.io/podman/stable@sha256:e968245017a54e31fec7583c589f1d68e5a14723e76d29861a887865c09084a0...
Getting image source signatures
Copying blob aaaf7db17b6d done  
Copying blob 72f8478ad099 done  
Copying blob 410ecb83fc0c done  
Copying blob be8c68cbb7d2 done  
Copying blob 62946078034b skipped: already exists  
Copying blob 81b10f9f3fc1 done  
Copying blob dc6f33153a37 done  
Copying blob f523c9884953 done  
Copying config 6a854277ec done  
Writing manifest to image destination
Storing signatures
6a854277ec3e96e0d578e6f83f9c29b47f694ebcb2b924a6d834399456159120