### PR TITLE
PLNSRVCE-646 : Sync workflows

### DIFF
--- a/.github/workflows/individual-image-scanner-quay.yaml
+++ b/.github/workflows/individual-image-scanner-quay.yaml
@@ -5,10 +5,18 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_run:
+    workflows:
+      - "Build and push images to quay"
+    branches:
+      - main
+    types:
+      - completed
 
 jobs:
   scans:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       access-setup-output: ${{ steps.access-setup-scan.outputs.VULNERABILITIES_EXIST }}
       cluster-setup-output: ${{ steps.cluster-setup-scan.outputs.VULNERABILITIES_EXIST }}


### PR DESCRIPTION
## Sync BuildPushImage and individualImageScanner workflows. 
### Changes 
Now, [IndividualImageScannerQuay](https://github.com/openshift-pipelines/pipeline-service/blob/main/.github/workflows/individual-image-scanner-quay.yaml) will run after [BuildPushImage](https://github.com/openshift-pipelines/pipeline-service/blob/main/.github/workflows/individual-image-scanner-quay.yaml) workflow and will be skipped if somehow BuildPushImage fails.
 
Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>