### PR TITLE
Use full version tag for the podman image

### DIFF
--- a/test/images/devenv/Dockerfile
+++ b/test/images/devenv/Dockerfile
@@ -1,5 +1,4 @@
-#FROM quay.io/podman/stable:v4
-FROM quay.io/podman/stable@sha256:e968245017a54e31fec7583c589f1d68e5a14723e76d29861a887865c09084a0
+FROM quay.io/podman/stable:v4.2.1
 
 RUN set -x \
     && mkdir ~/.kube \


### PR DESCRIPTION
Podman seems to remove some images, breaking our CI. Since this image is not a production image, using the x.y.z tag is good enough.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>