### PR TITLE
PLNSRVCE-777 : [M9]Deploy the workspace controller onto the staging cluster

### DIFF
--- a/ckcp/openshift_dev_setup.sh
+++ b/ckcp/openshift_dev_setup.sh
@@ -404,35 +404,6 @@ register_compute() {
     --crs-to-sync "$(IFS=,; echo "${CRS_TO_SYNC[*]}")" |
     indent 4
 
-  check_cr_sync
-}
-
-check_cr_sync() {
-  # Wait until CRDs are synced to KCP
-  echo -n "- Sync CRDs to KCP: "
-  local cr_regexp
-  cr_regexp="$(
-    IFS=\|
-    echo "${CRS_TO_SYNC[*]}"
-  )"
-  local wait_period=0
-  while [[ "$(KUBECONFIG="$KUBECONFIG_KCP" kubectl api-resources -o name 2>&1 | grep -Ewc "$cr_regexp")" -ne ${#CRS_TO_SYNC[@]} ]]; do
-    wait_period=$((wait_period + 10))
-    #when timeout, print out the CR resoures that is not synced to KCP
-    if [ "$wait_period" -gt 300 ]; then
-      echo "Failed to sync following resources to KCP: "
-      cr_synced=$(KUBECONFIG="$KUBECONFIG_KCP" kubectl api-resources -o name)
-      for cr in "${CRS_TO_SYNC[@]}"; do
-        if [ "$(echo "$cr_synced" | grep -wc "$cr")" -eq 0 ]; then
-          echo "    * $cr"
-        fi
-      done
-      exit 1
-    fi
-    echo -n "."
-    sleep 10
-  done
-  echo "OK"
 }
 
 main() {

--- a/gitops/README.md
+++ b/gitops/README.md
@@ -215,3 +215,9 @@ spec:
       path: root:${ORG_ID}:compute
 
 ```
+## Workspace Controller
+Pipeline Service deploys a controller named 'settings controller' into every kcp user workspace that is created for consuming Pipeline Service. This controller enforces a few restrictions in the user workspace such as Quotas and Network Policies.
+- Quotas limit the amount of compute resources that can be consumed.
+- NetworkPolicies restrict the access granted to the pods running the pipeline tasks to support hermetic builds.
+
+More information on the controller can be found [here](https://github.com/openshift-pipelines/pipeline-service-workspace-controller).

--- a/gitops/sre/environment/kcp/workspace-controller/base/kustomization.yaml
+++ b/gitops/sre/environment/kcp/workspace-controller/base/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github.com/openshift-pipelines/pipeline-service-workspace-controller/config/default

--- a/gitops/sre/environment/kcp/workspace-controller/overlays/kustomization.yaml
+++ b/gitops/sre/environment/kcp/workspace-controller/overlays/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+images:
+  - name: quay.io/redhat-pipeline-service/settings-operator
+    newName: quay.io/redhat-pipeline-service/settings-operator
+    newTag: latest
+namespace: settings-pipeline-service-controller


### PR DESCRIPTION
This PR includes the following changes:
- Added a new kustomization folder for workspace-controller under gitops/sre/.../kcp
- Modified register.sh under kcp-registrar to install workspace controller
- Modified the order in which check_cr_sync is called because we need to verify all the resources are available before applying the controller manifests. As part of this change, moved the function from ckcp to register.sh script.
- Updated README under gitops

Local run output (trimmed):

```
    Configuring KCP workspace
      clusterrole.rbac.authorization.k8s.io/apibinding:kubernetes unchanged
      clusterrolebinding.rbac.authorization.k8s.io/apibinding:kubernetes:all-users unchanged
    - Sync CRDs to KCP: OK
    Deploying Workspace Controller into the workspace
      namespace/settings-pipeline-service-controller created
      serviceaccount/settings-controller-manager created
      role.rbac.authorization.k8s.io/settings-leader-election-role created
      clusterrole.rbac.authorization.k8s.io/settings-kcp-manager-role created
      clusterrole.rbac.authorization.k8s.io/settings-manager-role created
      rolebinding.rbac.authorization.k8s.io/settings-leader-election-rolebinding created
      clusterrolebinding.rbac.authorization.k8s.io/settings-kcp-manager-rolebinding created
      clusterrolebinding.rbac.authorization.k8s.io/settings-manager-rolebinding created
      configmap/settings-manager-config created
      deployment.apps/settings-controller-manager created
      apibinding.apis.kcp.dev/settings-configuration.pipeline-service.io created
      apiexport.apis.kcp.dev/settings-configuration.pipeline-service.io created
      apiresourceschema.apis.kcp.dev/settings-today.settings.configuration.pipeline-service.io created

Use the below KUBECONFIG to get access to the kcp workspace and compute cluster respectively.
KUBECONFIG_KCP: /tmp/tmp.96RBPt2stm/credentials/kubeconfig/kcp/admin.kubeconfig.base
KUBECONFIG: /tmp/tmp.96RBPt2stm/credentials/kubeconfig/compute/compute.kubeconfig.base

You can also set the following aliases to access the kcp workspace and compute cluster respectively.
alias kkcp='KUBECONFIG=/tmp/tmp.96RBPt2stm/credentials/kubeconfig/kcp/admin.kubeconfig.base kubectl'
alias kcompute='KUBECONFIG=/tmp/tmp.96RBPt2stm/credentials/kubeconfig/compute/compute.kubeconfig.base kubectl'

```