### PR TITLE
Use CONTAINER_ENGINE instead of podman

### DIFF
--- a/developer/ckcp/README.md
+++ b/developer/ckcp/README.md
@@ -26,6 +26,7 @@ Before you execute the script, you need:
 4. to install [yq](https://mikefarah.gitbook.io/yq/#install)
 6. to install [kubectl kcp plugin](https://github.com/kcp-dev/kcp/blob/main/docs/kubectl-kcp-plugin.md)
    Note: ckcp uses the official kcp image in order to run kcp in a pod (latest released versions). It is advisable to use the same version for the kcp plugin as the kcp core API (especially as KCP API is evolving quickly). The current version can be found in [DEPENDENCIES.md](../../DEPENDENCIES.md). Make sure to checkout the branch listed in the doc before installing the plugin.
+7. to install [podman](https://github.com/containers/podman) or [docker](https://www.docker.com/). If you have both you can control which is used by setting the `CONTAINER_ENGINE` environment variable (e.g. `export CONTAINER_ENGINE="podman"`). While we do not recommend it for security reasons, you can prefix the binary with `sudo` to force the execution as the root user (e.g. `export CONTAINER_ENGINE="sudo podman"`).
 
 You can run the openshift_dev_setup.sh script with or without parameters as specified below:
 

--- a/developer/docs/DEVELOPMENT.md
+++ b/developer/docs/DEVELOPMENT.md
@@ -29,7 +29,7 @@ By default, Argo CD is installed on both clusters. It is possible to deactivate 
 **_NOTES:_**
 
 1. Podman is used as the default container engine, if available on the machine. If both podman and docker are available it is possible to force the use of docker by setting an environment variable `CONTAINER_ENGINE=docker`.
-2. Podman defaults to running as sudo (root). To run podman in rootless mode, use the environment variable `ALLOW_ROOTLESS=true`. See the [kind documentation](https://kind.sigs.k8s.io/docs/user/rootless/) for the prerequisites.
+2. Podman defaults to running as rootless (see the [kind documentation](https://kind.sigs.k8s.io/docs/user/rootless/) for the prerequisites). To run podman as `root`, prefix `CONTAINER_ENGINE` with `sudo` (e.g. `CONTAINER_ENGINE="sudo docker"`).
 
 ---
 

--- a/developer/images/devenv/run.sh
+++ b/developer/images/devenv/run.sh
@@ -85,7 +85,6 @@ parse_args() {
 
 detect_container_engine() {
     CONTAINER_ENGINE="${CONTAINER_ENGINE:-}"
-    ALLOW_ROOTLESS="${ALLOW_ROOTLESS:-false}"
     if [[ -n "${CONTAINER_ENGINE}" ]]; then
         return
     fi
@@ -106,10 +105,7 @@ detect_container_engine() {
     fi
 
     # Default container engine is podman
-    CONTAINER_ENGINE="sudo podman"
-    if [[ "${ALLOW_ROOTLESS}" == "true" ]]; then
-        CONTAINER_ENGINE="podman"
-    fi
+    CONTAINER_ENGINE="podman"
 }
 
 get_image_name() {


### PR DESCRIPTION
Some developers do not use podman, or podman is causing trouble on their platform (e.g. macOs).
Scripts have been changed to use in order of preference:
- CONTAINER_ENGINE if set by the user
- podman
- docker

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>

Linked to #276