### PR TITLE
Allow workspace to be configured when deploying ckcp

### DIFF
--- a/developer/ckcp/README.md
+++ b/developer/ckcp/README.md
@@ -111,7 +111,7 @@ Considerations for testing a new component:-
 3. A user can modify the Custom Resources to be synced by the KCP Syncer by modifying [cr_to_sync](./config.yaml).
 4. Onboarding a new component requires creating a new Argo CD application in [argo-apps](../../operator/gitops/argocd/argo-apps/) and adding it to [kustomization.yaml](../../operator/gitops/argocd/argo-apps/kustomization.yaml).
 5. For testing, users need to modify only the git source path and ref of their Argo CD application to reflect their own Git repo.
-6. A user can also choose a different version of kcp than the one running by default by changing the value of [version.kcp](./config.yaml).
+6. A user can also choose a different version of kcp than the one running by default by changing the value of [kcp.version](./config.yaml).
 
 ### Reset ckcp
 

--- a/developer/ckcp/config.yaml
+++ b/developer/ckcp/config.yaml
@@ -11,24 +11,23 @@ git_url: https://github.com/openshift-pipelines/pipeline-service.git
 # git_ref refers to the git repo's ref to be considered as the source of truth for Argo CD applications.
 git_ref: main
 
-# crs_to_sync is a list of the CRs which need to be synced.
-crs_to_sync:
-  - deployments.apps
-  - services
-  - ingresses.networking.k8s.io
-  - networkpolicies.networking.k8s.io
-  - pipelines.tekton.dev
-  - pipelineruns.tekton.dev
-  - tasks.tekton.dev
-  - repositories.pipelinesascode.tekton.dev
+kcp:
+  # crs_to_sync is a list of the CRs which need to be synced.
+  crs_to_sync:
+    - deployments.apps
+    - services
+    - ingresses.networking.k8s.io
+    - networkpolicies.networking.k8s.io
+    - pipelines.tekton.dev
+    - pipelineruns.tekton.dev
+    - tasks.tekton.dev
+    - repositories.pipelinesascode.tekton.dev
+  version: v0.9.0
+  workspace: root:default:pipeline-service-compute
 
 # Applications to be deployed on the cluster
 apps:
   - pipeline_service # pipeline_service sets up Pipeline Service on the cluster.
-
-# versions
-version:
-  kcp: v0.9.0
 
 # Tekton results database credentials
 tekton_results_db:

--- a/developer/ckcp/openshift_dev_setup.sh
+++ b/developer/ckcp/openshift_dev_setup.sh
@@ -123,19 +123,26 @@ init() {
   GIT_REF=$(yq '.git_ref // "main"' "$CONFIG")
 
   # get list of CRs to sync
-  read -ra CRS_TO_SYNC <<< "$(yq eval '.crs_to_sync | join(" ")' "$CONFIG")"
+  read -ra CRS_TO_SYNC <<< "$(yq eval '.kcp.crs_to_sync | join(" ")' "$CONFIG")"
   if (( "${#CRS_TO_SYNC[@]}" <= 0 )); then
     CRS_TO_SYNC=(
                 "deployments.apps"
                 "services"
                 "ingresses.networking.k8s.io"
-		"networkpolicies.networking.k8s.io"
+                "networkpolicies.networking.k8s.io"
                 "pipelines.tekton.dev"
                 "pipelineruns.tekton.dev"
                 "tasks.tekton.dev"
-		"repositories.pipelinesascode.tekton.dev"
+                "repositories.pipelinesascode.tekton.dev"
               )
   fi
+
+  # Get kcp workspace
+  kcp_org=$(yq '.kcp.workspace' "$CONFIG" | sed 's/:[^:]*$//')
+  kcp_workspace=$(yq '.kcp.workspace' "$CONFIG" | sed 's/^.*://')
+
+  # Get kcp version
+  kcp_version="$(yq '.kcp.version' "$CONFIG")"
 
   # Create SRE repository folder
   WORK_DIR="${WORK_DIR:-}"
@@ -158,9 +165,6 @@ init() {
   KUBECONFIG="$WORK_DIR/credentials/kubeconfig/compute/compute.kubeconfig.base"
   KUBECONFIG_MERGED="merged-config.kubeconfig:$KUBECONFIG:$KUBECONFIG_KCP"
   export KUBECONFIG
-  kcp_org="root:default"
-  kcp_workspace="pipeline-service-compute"
-  kcp_version="$(yq '.version.kcp' "$CONFIG")"
 }
 
 # To ensure that dependencies are satisfied
@@ -398,7 +402,7 @@ register_compute() {
   echo "- Register compute to KCP"
   "$PROJECT_DIR/operator/images/kcp-registrar/bin/register.sh" \
     ${DEBUG:+"$DEBUG"} \
-    --kcp-org "root:default" \
+    --kcp-org "$kcp_org" \
     --kcp-workspace "$kcp_workspace" \
     --kcp-sync-tag "$kcp_version" \
     --workspace-dir "$WORK_DIR" \

--- a/developer/local/kcp/start.sh
+++ b/developer/local/kcp/start.sh
@@ -38,7 +38,7 @@ SCRIPT_DIR="$(
   pwd
 )"
 CONFIG="$(dirname "$(dirname "$SCRIPT_DIR")")/ckcp/config.yaml"
-KCP_VERSION=$(yq '.version.kcp' "$CONFIG")
+KCP_VERSION=$(yq '.kcp.version' "$CONFIG")
 KCP_DIR="${KCP_DIR:-}"
 
 kcp-binaries() {

--- a/operator/images/kcp-upgrade/upgrade.sh
+++ b/operator/images/kcp-upgrade/upgrade.sh
@@ -24,7 +24,7 @@ SCRIPT_DIR="$(
 )"
 
 CONFIG="$(dirname "$(dirname "$SCRIPT_DIR")")/developer/ckcp/config.yaml"
-current_kcp_version="$(yq '.version.kcp' "$CONFIG" | sed 's/v//' )"
+current_kcp_version="$(yq '.kcp.version' "$CONFIG" | sed 's/v//' )"
 
 latest_kcp_version="$(curl -s https://api.github.com/repos/kcp-dev/kcp/releases/latest | yq '.tag_name' | sed 's/v//' )"
 


### PR DESCRIPTION
The workspace in which the service is deployed can now be configured by changing the kcp.workspace value in config/config.yaml.

The structure of the config.yaml file has been modified to improve readability by grouping values together when possible.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>