### PR TITLE
Fix reset_ckcp.sh when using a custom workspace

### DIFF
--- a/ckcp/hack/util/reset_ckcp.sh
+++ b/ckcp/hack/util/reset_ckcp.sh
@@ -102,7 +102,7 @@ prechecks() {
       exit 1
     fi
     export KUBECONFIG="$KUBECONFIG"
-    KCP_KUBECONFIG="$WORK_DIR/credentials/kubeconfig/kcp/ckcp-ckcp.default.pipeline-service-compute.kubeconfig"
+    KCP_KUBECONFIG="$(find "$WORK_DIR/credentials/kubeconfig/kcp" -name \*.kubeconfig | head -1)"
     if [ ! -f "$KCP_KUBECONFIG" ]; then
       printf "\n[ERROR] Couldn't find the user's kcp workspace kubeconfig." >&2
       printf "\nExpected kcp KUBECONFIG dir:'WORK_DIR/credentials/kubeconfig/kcp'"


### PR DESCRIPTION
The name of the kubeconfig is not static, so the script has been modified to look for any kubeconfig file

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>