### PR TITLE
Update dependencies to include grpc_cli

### DIFF
--- a/shared/config/dependencies.yaml
+++ b/shared/config/dependencies.yaml
@@ -9,3 +9,4 @@ oc-kubectl: 4.11.4
 shellcheck: v0.8.0
 tektoncd-cli: v0.27.0
 yq: v4.28.1
+grpc_cli: v1.50.0

--- a/test/images/devenv/Dockerfile
+++ b/test/images/devenv/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/podman/stable:v4.2.1
 RUN set -x \
     && mkdir ~/.kube \
     && mkdir -p /tmp/dockerfile \
-    && dnf install -y git-2.37.3 openssl-3.0.2 procps-ng-3.3.17 unzip-6.0 which-2.21 xz-5.2.5 \
+    && dnf install -y cmake-3.22.2 gcc-c++-12.0.1 git-2.37.3 libtool-2.4.6 openssl-3.0.2 procps-ng-3.3.17 unzip-6.0 which-2.21 xz-5.2.5 \
     && dnf clean all
 
 COPY shared/config/dependencies.yaml /tmp/dockerfile/dependencies.yaml


### PR DESCRIPTION
Update dependencies to include and install grpc_cli
grpc_cli is used as part of the tests for tekton results to ensure results are stored correctly 
