### PR TITLE
the CI matches any target branch

### DIFF
--- a/.tekton/pipeline-service-static-code-analysis.yaml
+++ b/.tekton/pipeline-service-static-code-analysis.yaml
@@ -5,7 +5,7 @@ metadata:
   name: pipeline-service-static-code-analysis
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request, push]"
-    pipelinesascode.tekton.dev/on-target-branch: "main"
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/*]"
     pipelinesascode.tekton.dev/task: "[git-clone]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:


### PR DESCRIPTION
Because of PAC bug https://github.com/openshift-pipelines/pipelines-as-code/issues/944. the PipeineRun is firstly applied the main branch, see PR https://github.com/openshift-pipelines/pipeline-service/pull/320 , and then apply it to all branches