### PR TITLE
Fix cert-manager path in argocd app

### DIFF
--- a/developer/ckcp/hack/util/reset_ckcp.sh
+++ b/developer/ckcp/hack/util/reset_ckcp.sh
@@ -194,7 +194,7 @@ uninstall_operators(){
     fi
 
     printf "\n  Uninstalling cert-manager Operator:\n"
-    kubectl delete -k "$PROJECT_DIR/operators/cert-manager" --ignore-not-found=true
+    kubectl delete -k "$PROJECT_DIR/operator/cert-manager" --ignore-not-found=true
     mapfile -t cert_manager_crds < <(kubectl get crd | grep -iE "cert-manager.io|certmanagers" | cut -d " " -f 1)
     if [[ "${#cert_manager_crds[@]}" -gt 0 ]]; then
       for crd in "${cert_manager_crds[@]}"; do

--- a/developer/ckcp/openshift_dev_setup.sh
+++ b/developer/ckcp/openshift_dev_setup.sh
@@ -238,12 +238,7 @@ install_cert_manager(){
   APP="cert-manager-operator"
   echo "- OpenShift-Cert-Manager: "
   kubectl apply -f "$GITOPS_DIR/argocd/argo-apps/$APP.yaml" >/dev/null
-  check_cert_manager | indent 2
-}
-
-check_cert_manager() {
-  certManagerDeployments=("cert-manager" "cert-manager-cainjector" "cert-manager-webhook")
-  check_deployments "openshift-cert-manager" "${certManagerDeployments[@]}"
+  check_deployments "openshift-cert-manager" "cert-manager" "cert-manager-cainjector" "cert-manager-webhook" | indent 2
 }
 
 install_ckcp() {

--- a/operator/gitops/argocd/argo-apps/cert-manager-operator.yaml
+++ b/operator/gitops/argocd/argo-apps/cert-manager-operator.yaml
@@ -9,7 +9,7 @@ spec:
     namespace: openshift-gitops
     server: https://kubernetes.default.svc
   source:
-    path: operators/cert-manager
+    path: operator/cert-manager
     repoURL: https://github.com/openshift-pipelines/pipeline-service.git
     targetRevision: main
   project: default


### PR DESCRIPTION
After layout reorg in 7797894, the cert-manager-operator path has changed, this commit updates a reference to the path in argo-cd app and simplifies cert-manager deployment check.