### PR TITLE
Change default branch reference to `freeze` for freeze branch

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,7 +9,7 @@ cluster_type: openshift
 git_url: https://github.com/openshift-pipelines/pipeline-service.git
 
 # git_ref refers to the git repo's ref to be considered as the source of truth for Argo CD applications.
-git_ref: main
+git_ref: freeze
 
 # crs_to_sync is a list of the CRs which need to be synced.
 crs_to_sync:

--- a/gitops/argocd/argo-apps/cert-manager-operator.yaml
+++ b/gitops/argocd/argo-apps/cert-manager-operator.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: operators/cert-manager
     repoURL: https://github.com/openshift-pipelines/pipeline-service.git
-    targetRevision: main
+    targetRevision: freeze
   project: default
   syncPolicy:
     # Comment this out if you want to manually trigger deployments (using the

--- a/gitops/argocd/argo-apps/tekton-chains.yaml
+++ b/gitops/argocd/argo-apps/tekton-chains.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     path: gitops/argocd/tekton-chains/overlays/openshift
     repoURL: https://github.com/openshift-pipelines/pipeline-service.git
-    targetRevision: main
+    targetRevision: freeze
   project: default
   syncPolicy:
 

--- a/gitops/argocd/argo-apps/tekton-results.yaml
+++ b/gitops/argocd/argo-apps/tekton-results.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     path: gitops/argocd/tekton-results
     repoURL: https://github.com/openshift-pipelines/pipeline-service.git
-    targetRevision: main
+    targetRevision: freeze
   project: default
   syncPolicy:
 

--- a/gitops/argocd/argo-apps/tektoncd.yaml
+++ b/gitops/argocd/argo-apps/tektoncd.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: gitops/argocd/tektoncd
     repoURL: https://github.com/openshift-pipelines/pipeline-service.git
-    targetRevision: main
+    targetRevision: freeze
   project: default
   syncPolicy:
     # Comment this out if you want to manually trigger deployments (using the

--- a/gitops/argocd/argocd.yaml
+++ b/gitops/argocd/argocd.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: gitops/argocd/argo-apps
     repoURL: https://github.com/openshift-pipelines/pipeline-service.git
-    targetRevision: main
+    targetRevision: freeze
   project: default
   syncPolicy:
     # Comment this out if you want to manually trigger deployments (using the


### PR DESCRIPTION
### Why this PR
People are running into issues due to broken links in `ckcp` due to default argo cd source path referencing `main` branch. 
This PR will fix the broken link issue in  `freeze` branch.

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>