### PR TITLE
PLNSRVCE-778 : Replacing set-output with GITHUB_OUTPUT as it is deprecated in Github actions

### DIFF
--- a/.github/workflows/argocd-registrar-image.yaml
+++ b/.github/workflows/argocd-registrar-image.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get the short sha
         id: vars
-        run: echo "::set-output name=sha_short::$(echo ${{ github.sha }} | cut -b -7)"
+        run: echo "sha_short=$(echo ${{ github.sha }} | cut -b -7)" >> $GITHUB_OUTPUT
       # Build and push an argocd-registrar image, tagged with latest and the commit SHA.
       - name: Build argocd-registrar Image
         id: build-image

--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get the short sha
         id: vars
-        run: echo "::set-output name=sha_short::$(echo ${{ github.sha }} | cut -b -7)"
+        run: echo "sha_short=$(echo ${{ github.sha }} | cut -b -7)" > $GITHUB_OUTPUT
 
       - uses: dorny/paths-filter@v2
         id: filter

--- a/.github/workflows/individual-image-scanner-quay.yaml
+++ b/.github/workflows/individual-image-scanner-quay.yaml
@@ -59,7 +59,7 @@ jobs:
         if: steps.filter.outputs.access-setup == 'true'
         run: |
           ./ci/images/vulnerability-scan/scan-image.sh | tee /tmp/clair-scan.log
-          echo "::set-output name=VULNERABILITIES_EXIST::$(tail -1 /tmp/clair-scan.log)"
+          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
         env:
           AUTH_BEARER_TOKEN: ${{ secrets.AUTH_BEARER_TOKEN }}
           IMAGE_NAME: access-setup
@@ -70,7 +70,7 @@ jobs:
         if: steps.filter.outputs.cluster-setup == 'true'
         run: |
           ./ci/images/vulnerability-scan/scan-image.sh | tee /tmp/clair-scan.log
-          echo "::set-output name=VULNERABILITIES_EXIST::$(tail -1 /tmp/clair-scan.log)"
+          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
         env:
           AUTH_BEARER_TOKEN: ${{ secrets.AUTH_BEARER_TOKEN }}
           IMAGE_NAME: cluster-setup
@@ -81,7 +81,7 @@ jobs:
         if: steps.filter.outputs.devenv == 'true'
         run: |
           ./ci/images/vulnerability-scan/scan-image.sh | tee /tmp/clair-scan.log
-          echo "::set-output name=VULNERABILITIES_EXIST::$(tail -1 /tmp/clair-scan.log)"
+          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
         env:
           AUTH_BEARER_TOKEN: ${{ secrets.AUTH_BEARER_TOKEN }}
           IMAGE_NAME: devenv
@@ -92,7 +92,7 @@ jobs:
         if: steps.filter.outputs.kcp-registrar == 'true'
         run: |
           ./ci/images/vulnerability-scan/scan-image.sh | tee /tmp/clair-scan.log
-          echo "::set-output name=VULNERABILITIES_EXIST::$(tail -1 /tmp/clair-scan.log)"
+          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
         env:
           AUTH_BEARER_TOKEN: ${{ secrets.AUTH_BEARER_TOKEN }}
           IMAGE_NAME: kcp-registrar
@@ -103,7 +103,7 @@ jobs:
         if: steps.filter.outputs.quay-upload == 'true'
         run: |
           ./ci/images/vulnerability-scan/scan-image.sh | tee /tmp/clair-scan.log
-          echo "::set-output name=VULNERABILITIES_EXIST::$(tail -1 /tmp/clair-scan.log)"
+          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
         env:
           AUTH_BEARER_TOKEN: ${{ secrets.AUTH_BEARER_TOKEN }}
           IMAGE_NAME: quay-upload
@@ -114,7 +114,7 @@ jobs:
         if: steps.filter.outputs.shellcheck == 'true'
         run: |
           ./ci/images/vulnerability-scan/scan-image.sh | tee /tmp/clair-scan.log
-          echo "::set-output name=VULNERABILITIES_EXIST::$(tail -1 /tmp/clair-scan.log)"
+          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
         env:
           AUTH_BEARER_TOKEN: ${{ secrets.AUTH_BEARER_TOKEN }}
           IMAGE_NAME: shellcheck
@@ -125,7 +125,7 @@ jobs:
         if: steps.filter.outputs.update-pipeline-service == 'true'
         run: |
           ./ci/images/vulnerability-scan/scan-image.sh | tee /tmp/clair-scan.log
-          echo "::set-output name=VULNERABILITIES_EXIST::$(tail -1 /tmp/clair-scan.log)"
+          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
         env:
           AUTH_BEARER_TOKEN: ${{ secrets.AUTH_BEARER_TOKEN }}
           IMAGE_NAME: update-pipeline-service
@@ -136,7 +136,7 @@ jobs:
         if: steps.filter.outputs.vulnerability == 'true'
         run: |
           ./ci/images/vulnerability-scan/scan-image.sh | tee /tmp/clair-scan.log
-          echo "::set-output name=VULNERABILITIES_EXIST::$(tail -1 /tmp/clair-scan.log)"
+          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
         env:
           AUTH_BEARER_TOKEN: ${{ secrets.AUTH_BEARER_TOKEN }}
           IMAGE_NAME: vulnerability-scan
@@ -147,7 +147,7 @@ jobs:
         if: steps.filter.outputs.yamllint == 'true'
         run: |
           ./ci/images/vulnerability-scan/scan-image.sh | tee /tmp/clair-scan.log
-          echo "::set-output name=VULNERABILITIES_EXIST::$(tail -1 /tmp/clair-scan.log)"
+          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
         env:
           AUTH_BEARER_TOKEN: ${{ secrets.AUTH_BEARER_TOKEN }}
           IMAGE_NAME: yamllint

--- a/.github/workflows/kcp-upgrade.yaml
+++ b/.github/workflows/kcp-upgrade.yaml
@@ -21,8 +21,8 @@ jobs:
         run: |
           ./operator/images/kcp-upgrade/upgrade.sh
           if [ -e "/tmp/kcp-upgrade.txt" ]; then
-            echo "::set-output name=NEW_KCP_VERSION::$(cat "/tmp/kcp-upgrade.txt" | sed 's/v//')"
-            echo "::set-output name=NEW_KCP_VERSION_FOUND::true"
+            echo "NEW_KCP_VERSION=$(cat "/tmp/kcp-upgrade.txt" | sed 's/v//')" >> $GITHUB_OUTPUT
+            echo "NEW_KCP_VERSION_FOUND=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Create PR if a new kcp version exists

--- a/.github/workflows/periodic-scanner-quay.yaml
+++ b/.github/workflows/periodic-scanner-quay.yaml
@@ -19,7 +19,7 @@ jobs:
         id: fetch-results
         run: |
           ./ci/images/vulnerability-scan/scan.sh | tee /tmp/vulnerability-scan.log
-          echo "::set-output name=VULNERABILITIES_EXIST::$(tail -1 /tmp/vulnerability-scan.log)"
+          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/vulnerability-scan.log)" >> $GITHUB_OUTPUT
         env:
           AUTH_BEARER_TOKEN: ${{ secrets.AUTH_BEARER_TOKEN }}
 


### PR DESCRIPTION
We get the below warning in our Github actions at the moment. This PR fixes the issue.

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/