### PR TITLE
Capture return status in the function call inline to fix the issue with vulnerability scanners

### DIFF
--- a/ci/images/vulnerability-scan/common/utils.sh
+++ b/ci/images/vulnerability-scan/common/utils.sh
@@ -61,7 +61,6 @@ get_vulnerabilities() {
         return 1
       else
         printf "No vulnerabilities found \n"
-        return 0
       fi
     return
     else

--- a/ci/images/vulnerability-scan/scan-image.sh
+++ b/ci/images/vulnerability-scan/scan-image.sh
@@ -25,12 +25,11 @@ SCRIPT_DIR="$(
 # shellcheck source=ci/images/vulnerability-scan/common/utils.sh
 source "$SCRIPT_DIR/common/utils.sh"
 
-VULNERABILITIES_EXIST=1
+VULNERABILITIES_EXIST=0
 
 main() {
     get_digest "$IMAGE_NAME"
-    get_vulnerabilities "$IMAGE_NAME"
-    VULNERABILITIES_EXIST=$?
+    get_vulnerabilities "$IMAGE_NAME" || VULNERABILITIES_EXIST=$?
     printf "%s" "$VULNERABILITIES_EXIST"
 }
 

--- a/ci/images/vulnerability-scan/scan.sh
+++ b/ci/images/vulnerability-scan/scan.sh
@@ -31,8 +31,7 @@ images_vul=("${images[@]/*/1}")
 main() {
   for i in "${!images[@]}"; do
     get_digest "${images[i]}"
-    get_vulnerabilities "${images[i]}"
-    images_vul[i]=$?
+    get_vulnerabilities "${images[i]}" || images_vul[i]=$?
   done
   printf "%s " "${images_vul[@]}"
 }


### PR DESCRIPTION
From the logs of a latest run. Instead of the value of res being 0 or 1, the script exits prematurely causing the value to be set to some string. This PR fixes this issue.

```
Run res= Check the full report here: https://quay.io/repository/redhat-pipeline-service/vulnerability-scan/manifest/sha256:92f5cf046[1](https://github.com/openshift-pipelines/pipeline-service/actions/runs/3389846804/jobs/5633369718#step:9:1)bdedb54e66bf2e6a489b16f67ef941aad27cf62f1f25976c29736f?tab=vulnerabilities 
/home/runner/work/_temp/00184d58-34aa-45fb-90ff-56d51ab33496.sh: line 1: Check: command not found
Error: Process completed with exit code [12](https://github.com/openshift-pipelines/pipeline-service/actions/runs/3389846804/jobs/5633369718#step:9:13)7.
```