### PR TITLE
fix update-pipeline-service

### DIFF
--- a/operator/images/update-pipeline-service/bin/gitlab.sh
+++ b/operator/images/update-pipeline-service/bin/gitlab.sh
@@ -187,8 +187,8 @@ gitlab_process() {
   retry=${retry:-}
 
   # main
-  get_current_commit
   get_latest_commit
+  get_current_commit
   update_local_repository
   get_mr_id
   if [ "$merge_request_iid" != "null" ]; then


### PR DESCRIPTION
Improper ordering of 2 function calls was triggering an 'unbound variable' error

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>