### PR TITLE
[WIP] PLNSRVCE-812 : minimize use of wildcard while defining RBAC

### DIFF
--- a/developer/exploration/argocd-external/gitops/sre/environment/compute/base/argocd-rbac/argo-syncer-role.yaml
+++ b/developer/exploration/argocd-external/gitops/sre/environment/compute/base/argocd-rbac/argo-syncer-role.yaml
@@ -10,4 +10,11 @@ rules:
     resources:
       - "*"
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection

--- a/developer/exploration/argocd-external/gitops/sre/environment/compute/base/argocd-rbac/argo-tekton-role.yaml
+++ b/developer/exploration/argocd-external/gitops/sre/environment/compute/base/argocd-rbac/argo-tekton-role.yaml
@@ -10,4 +10,11 @@ rules:
     resources:
       - "*"
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection

--- a/operator/gitops/compute/pac-manager/role.yaml
+++ b/operator/gitops/compute/pac-manager/role.yaml
@@ -9,8 +9,22 @@ rules:
     resources:
       - "*"
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
   - nonResourceURLs:
       - "*"
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection

--- a/operator/gitops/kcp/pac-manager/role.yaml
+++ b/operator/gitops/kcp/pac-manager/role.yaml
@@ -9,8 +9,22 @@ rules:
     resources:
       - "*"
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
   - nonResourceURLs:
       - "*"
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection


### PR DESCRIPTION

##### Using wildcard for defining verbs in Roles and ClusterRoles may lead to furnishing more permissions for an object like a ServiceAccount than required and so defining verbs explicitly can help minimize this. 

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>