### PR TITLE
Create configmap for configuring tekton-results

### DIFF
--- a/operator/gitops/argocd/tekton-results/configmap.yaml
+++ b/operator/gitops/argocd/tekton-results/configmap.yaml
@@ -10,3 +10,32 @@ metadata:
     app.kubernetes.io/version: v0.4.0
   name: tekton-results-database
   namespace: tekton-results
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tekton-results-config
+  namespace: tekton-results
+data:
+  config: |
+    DB_USER=
+    DB_PASSWORD=
+    DB_HOST=
+    DB_PORT=5432
+    DB_NAME=
+    DB_SSLMODE=disable
+    GRPC_PORT=50051
+    REST_PORT=8080
+    PROMETHEUS_PORT=9090
+    TLS_HOSTNAME_OVERRIDE=
+    TLS_PATH=/etc/tls
+    LOG_TYPE=File
+    LOG_CHUNK_SIZE=32768
+    LOGS_DATA=
+    S3_BUCKET_NAME=
+    S3_ENDPOINT=
+    S3_HOSTNAME_IMMUTABLE=false
+    S3_REGION=
+    S3_ACCESS_KEY_ID=
+    S3_SECRET_ACCESS_KEY=
+    S3_MULTI_PART_SIZE=5242880

--- a/operator/gitops/argocd/tekton-results/deployment.yaml
+++ b/operator/gitops/argocd/tekton-results/deployment.yaml
@@ -38,21 +38,28 @@ spec:
                   name: tekton-results-database
             - name: DB_PROTOCOL
               value: tcp
-            - name: DB_ADDR
+            - name: DB_HOST
               value: tekton-results-database-service.tekton-results.svc.cluster.local
             - name: DB_NAME
               value: tekton_results
-          image: quay.io/redhat-appstudio/tekton-results-api@sha256:dca434dccd576e7a186098779f678422f10ac16b395c67944ffa50633fc3dd2e
+          image: quay.io/redhat-appstudio/tekton-results-api@sha256:56471d0c0582e8c4e4c109ef615b66e94a7fba258ab5960e36adce71d5a6e7f1
           name: api
           volumeMounts:
             - mountPath: /etc/tls
               name: tls
+              readOnly: true
+            - name: config
+              mountPath: /config/env
               readOnly: true
       serviceAccountName: tekton-results-api
       volumes:
         - name: tls
           secret:
             secretName: tekton-results-tls
+        - name: config
+          configMap:
+            name: tekton-results-config
+            defaultMode: 420
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -85,7 +92,7 @@ spec:
             - tekton-results-api-service.tekton-results.svc.cluster.local:50051
             - -auth_mode
             - token
-          image: quay.io/redhat-appstudio/tekton-results-watcher@sha256:801bfcfd4292dfd1239f638bcf88b0becb15af1263b81aff13f4f14db272e787
+          image: quay.io/redhat-appstudio/tekton-results-watcher@sha256:2a3ae9fca05bfef0195f6d11a2c1b6111288617bad4f7106400330c7fb016d14
           name: watcher
           volumeMounts:
             - mountPath: /etc/tls


### PR DESCRIPTION
Create configmap on cluster and mount in the tekton-results api container. 
This will fix an issue where results is trying to load the config file and gives an error. 
It will also allow configuring tekton results by file in the future if needed. 