### PR TITLE
PLNSRVCE-730: [M9]Migrate infra credentials to Bitwarden

### DIFF
--- a/operator/docs/sre/examples/providers/credentials/secrets/aws-secret-manager.yaml
+++ b/operator/docs/sre/examples/providers/credentials/secrets/aws-secret-manager.yaml
@@ -1,0 +1,9 @@
+# Note: Currently, AWS Secret manager is not supported. This is shown as an example to demonstrate
+# that it is possible to integrate multiple secret managers with Pipeline Service
+credentials:
+  # tekton chains signing secrets
+  - id: 1234abcd-abcd-1234-abcd-1234abcd1234
+    path: credentials/manifests/compute/tekton-chains/signing-secrets.yaml
+  # tekton results secrets
+  - id: 1234abcd-abcd-1234-abcd-1234abcd1234
+    path: credentials/manifests/compute/tekton-results/tekton-results-secret.yaml

--- a/operator/docs/sre/examples/providers/credentials/secrets/aws-secret-manager.yaml
+++ b/operator/docs/sre/examples/providers/credentials/secrets/aws-secret-manager.yaml
@@ -1,3 +1,4 @@
+---
 # Note: Currently, AWS Secret manager is not supported. This is shown as an example to demonstrate
 # that it is possible to integrate multiple secret managers with Pipeline Service
 credentials:

--- a/operator/docs/sre/examples/providers/credentials/secrets/bitwarden.yaml
+++ b/operator/docs/sre/examples/providers/credentials/secrets/bitwarden.yaml
@@ -1,3 +1,4 @@
+---
 credentials:
   # tekton chains signing secrets
   - id: 1234abcd-abcd-1234-abcd-1234abcd1234

--- a/operator/docs/sre/examples/providers/credentials/secrets/bitwarden.yaml
+++ b/operator/docs/sre/examples/providers/credentials/secrets/bitwarden.yaml
@@ -1,0 +1,7 @@
+credentials:
+  # tekton chains signing secrets
+  - id: 1234abcd-abcd-1234-abcd-1234abcd1234
+    path: credentials/manifests/compute/tekton-chains/signing-secrets.yaml
+  # tekton results secrets
+  - id: 1234abcd-abcd-1234-abcd-1234abcd1234
+    path: credentials/manifests/compute/tekton-results/tekton-results-secret.yaml

--- a/operator/docs/sre/examples/single_cluster/credentials/manifests/compute/tekton-results/tekton-results-secret.yaml
+++ b/operator/docs/sre/examples/single_cluster/credentials/manifests/compute/tekton-results/tekton-results-secret.yaml
@@ -1,0 +1,10 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: tekton-results-database
+  namespace: tekton-results
+data:
+  DATABASE_PASSWORD: password
+  DATABASE_USER: username
+type: Opaque

--- a/operator/docs/sre/examples/single_cluster/credentials/secrets/bitwarden.yaml
+++ b/operator/docs/sre/examples/single_cluster/credentials/secrets/bitwarden.yaml
@@ -1,7 +1,0 @@
-credentials:
-  # tekton chains signing secrets
-  - id: 1234abcd-abcd-1234-abcd-1234abcd1234
-    path: credentials/manifests/compute/tekton-chains/signing-secrets.yaml
-  # tekton results secrets
-  - id: 1234abcd-abcd-1234-abcd-1234abcd1234
-    path: credentials/manifests/compute/tekton-results/tekton-results-secret.yaml

--- a/operator/docs/sre/examples/single_cluster/credentials/secrets/bitwarden.yaml
+++ b/operator/docs/sre/examples/single_cluster/credentials/secrets/bitwarden.yaml
@@ -1,0 +1,7 @@
+credentials:
+  # tekton chains signing secrets
+  - id: 1234abcd-abcd-1234-abcd-1234abcd1234
+    path: credentials/manifests/compute/tekton-chains/signing-secrets.yaml
+  # tekton results secrets
+  - id: 1234abcd-abcd-1234-abcd-1234abcd1234
+    path: credentials/manifests/compute/tekton-results/tekton-results-secret.yaml

--- a/operator/gitops/sre/credentials/secrets/README.md
+++ b/operator/gitops/sre/credentials/secrets/README.md
@@ -3,9 +3,18 @@
 This directory contains files that store secrets from secret managers like Bitwarden, Vault, AWS Secret manager etc.
 An example of such a secret could be credentials (username and password) to connect to a remote database such as AWS RDS.
 
-The format in which the secrets need to be available in this directory is shown below:
+The contents of the file under secrets directory should follow the below structure:
+```
+credentials:
+  - id: 
+    path: 
+  - id:
+    path:
+```
 
-Create a new file named `bitwarden.yaml` under secrets directory.
+### Bitwarden Example  
+
+Create a new file named `bitwarden.yaml` under secrets directory and provide a list of id & path values for each secret.
 ```
 credentials:
   # tekton chains signing secrets
@@ -16,17 +25,8 @@ credentials:
     path: credentials/manifests/compute/tekton-results/tekton-results-secret.yaml
 ```
 
-Note: At the moment, only Bitwarden is supported. Please raise an issue/PR for the support of any other secret manager tools.
-
-The contents of the file should follow the structure:
-```
-credentials:
-  - id: 
-    path: 
-  - id:
-    path:
-```
-
-We then parse this file (bitwarden.yaml), fetch the secret from Bitwarden based on the value of the ID and replace that secret at the value of path.
+- At the moment, only Bitwarden is supported. Please raise an issue/PR for the support of any other secret manager tools.
+- The secret stored in the secret manager tools must be the content of the file you're trying to protect in base64 encoded form.
+- We then parse the file, fetch the secret from Bitwarden based on the value of the ID and replace that secret at the value of path.
 
 Please check [sre examples](operator/docs/sre/examples) directory for more details.

--- a/operator/gitops/sre/credentials/secrets/README.md
+++ b/operator/gitops/sre/credentials/secrets/README.md
@@ -1,0 +1,32 @@
+# Secrets from secret managers
+
+This directory contains files that store secrets from secret managers like Bitwarden, Vault, AWS Secret manager etc.
+An example of such a secret could be credentials (username and password) to connect to a remote database such as AWS RDS.
+
+The format in which the secrets need to be available in this directory is shown below:
+
+Create a new file named `bitwarden.yaml` under secrets directory.
+```
+credentials:
+  # tekton chains signing secrets
+  - id: 1234abcd-abcd-1234-abcd-1234abcd1234
+    path: credentials/manifests/compute/tekton-chains/signing-secrets.yaml
+  # tekton results secrets
+  - id: 1234abcd-abcd-1234-abcd-1234abcd1234
+    path: credentials/manifests/compute/tekton-results/tekton-results-secret.yaml
+```
+
+Note: At the moment, only Bitwarden is supported. Please raise an issue/PR for the support of any other secret manager tools.
+
+The contents of the file should follow the structure:
+```
+credentials:
+  - id: 
+    path: 
+  - id:
+    path:
+```
+
+We then parse this file (bitwarden.yaml), fetch the secret from Bitwarden based on the value of the ID and replace that secret at the value of path.
+
+Please check [sre examples](operator/docs/sre/examples) directory for more details.


### PR DESCRIPTION
- Fetch secrets from Bitwarden and replace those values in the corresponding files.
- Docs directory updated with relevant examples.
- SRE directory updated with README.
- Enable/disable tracing to hide secrets.

Local run output (truncated):

```
  - Deploy compute:
    [Bitwarden]:   
      bitwarden.yaml file exists. Checking if the required variables to connect to Bitwarden are set.
      Required variables are available.
      Extracted secrets from Bitwarden and substituted them in the relevant files.
    [Compute a9265aeffb3cc4f94a9f7138a8ef389e-ffc1c735f0a0b5bc-elb-us-east-1-amazonaws-com]:
    - Installing shared manifests... 
        namespace/tekton-results configured
        secret/tekton-results-database unchanged
    - Installing applications via Openshift GitOps... 
        application.argoproj.io/pipeline-service unchanged
    - Checking deployment status
        - tekton-pipelines-controller: Exists, Ready

```