### PR TITLE
fix access-setup/setup_kcp.sh

### DIFF
--- a/operator/images/access-setup/content/bin/setup_kcp.sh
+++ b/operator/images/access-setup/content/bin/setup_kcp.sh
@@ -175,9 +175,6 @@ patches:
         path: /spec/template/spec/containers/0/args/2
         value: \"--api-export-workspace=$KCP_ORG:$KCP_WORKSPACE\"
 " >> "$manifests_dir/overlays/kustomization.yaml"
-  echo -n "---
-- 
-" > "$manifests_dir/overlays/workspace.yaml"
   printf "OK\n"
 }
 


### PR DESCRIPTION
Removed the generation of environment/kcp/workspace-controller/overlays/workspace.yaml which was unused

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>