### PR TITLE
Fix bitwarden installation

### DIFF
--- a/developer/images/devenv/Dockerfile
+++ b/developer/images/devenv/Dockerfile
@@ -18,9 +18,7 @@ RUN set -x \
 
 COPY shared /tmp/image-build/shared
 
-WORKDIR /tmp/image-build/shared/hack
-
-RUN ./install.sh --debug --bin argocd,bitwarden,grpc_cli,hadolint,jq,kcp,kind,kubectl,oc,shellcheck,tkn,yamllint,yq \
+RUN /tmp/image-build/shared/hack/install.sh --debug --bin argocd,bitwarden,grpc_cli,hadolint,jq,kcp,kind,kubectl,oc,shellcheck,tkn,yamllint,yq \
     && rm -rf /tmp/image-build
 
 WORKDIR "/workspace"

--- a/operator/images/cluster-setup/Dockerfile
+++ b/operator/images/cluster-setup/Dockerfile
@@ -17,18 +17,17 @@ LABEL build-date= \
       version="0.1"
 WORKDIR /
 RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
-ENV HOME /tmp/home
-RUN mkdir $HOME && chmod 777 $HOME && chown 65532:65532 $HOME
 RUN microdnf install -y findutils-4.6.0 git-2.31.1  unzip-6.0 && microdnf clean all
 
 COPY shared /tmp/image-build/shared
-WORKDIR /tmp/image-build/shared/hack
-RUN set -x \
-    && ./install.sh --bin bitwarden,jq,kubectl \
+RUN /tmp/image-build/shared/hack/install.sh --bin bitwarden,jq,kubectl,yq \
     && rm -rf /tmp/image-build
 
 COPY operator/images/cluster-setup/content /opt/cluster-setup
+
 USER 65532:65532
+ENV HOME /tmp/home
+RUN mkdir $HOME
 VOLUME /workspace
 WORKDIR /workspace
 ENTRYPOINT ["/opt/cluster-setup/bin/install.sh"]

--- a/shared/hack/install.sh
+++ b/shared/hack/install.sh
@@ -134,9 +134,8 @@ install_argocd() {
 }
 
 install_bitwarden() {
-    curl "${CURL_OPTS[@]}" -o "$TMPBIN/bw.zip" "https://github.com/bitwarden/clients/releases/download/cli-${BITWARDEN_VERSION}/bw-linux-${BITWARDEN_VERSION:1}.zip"
-    unzip "$TMPBIN/bw.zip" -d "$TMPBIN/"
-    rm -rf "$TMPBIN/bw.zip"
+    curl "${CURL_OPTS[@]}" -o "$TMPDIR/bw.zip" "https://github.com/bitwarden/clients/releases/download/cli-${BITWARDEN_VERSION}/bw-linux-${BITWARDEN_VERSION:1}.zip"
+    unzip -q "$TMPDIR/bw.zip" -d "$TMPBIN/"
     move_bin
     bw --version
 }


### PR DESCRIPTION
During the image creation 'bw --version' was run as root while $HOME was already set to '/tmp/home'. This generated files in $HOME/.config owned by root, causing a failure when 'bw' was called again as a different user.

- The 'install_bitwarden' function has been cleaned up.
- The Dockerfiles for 'cluster-setup' and 'devenv' have been modified so that $HOME is set after all dependencies installation.
- Add missing yq dependency to cluster-setup
- Fix issue when the workspace is read-only for the user.
- Fix issue with tracing being activated in the middle of the install.
- Fix credential leak

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>