### PR TITLE
Removing tmp folder in install.sh as its breaking deployment on staging cluster

### DIFF
--- a/operator/images/cluster-setup/content/bin/install.sh
+++ b/operator/images/cluster-setup/content/bin/install.sh
@@ -78,15 +78,6 @@ parse_args() {
   DEBUG="${DEBUG:-}"
 }
 
-init() {
-  local tmp_workspace_dir="/tmp/workspace"
-  if [[ -e "$tmp_workspace_dir" ]]; then
-    rm -rf "$tmp_workspace_dir"
-  fi
-  cp -rf "$WORKSPACE_DIR" "$tmp_workspace_dir"
-  WORKSPACE_DIR="$tmp_workspace_dir"
-}
-
 # turns off tracing even with set -x mode enabled across the script to prevent secrets leaking
 setx_off() {
   set +x
@@ -233,7 +224,6 @@ install_applications() {
 
 main() {
   parse_args "$@"
-  init
   fetch_bitwarden_secrets
   get_clusters
   install_clusters


### PR DESCRIPTION
- Moving files into /tmp folder and assigning that as the workspace path is causing issues in the Gitlab CI.
- Corresponding PR has already been raised on Gitlab with more details.