### PR TITLE
PLNSRVCE-812 : Defining RBAC manifest a/c to RBAC best practices-

### DIFF
--- a/operator/gitops/compute/pipeline-service-manager/role.yaml
+++ b/operator/gitops/compute/pipeline-service-manager/role.yaml
@@ -5,12 +5,106 @@ metadata:
   name: pipeline-service-admin
 rules:
   - apiGroups:
-      - "*"
+      - ""
     resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
       - "*"
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - "*"
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingress
+      - networkpolicies
+    verbs:
+      - "*"
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - create
+      - bind
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - pipelines
+      - tasks
+    verbs:
+      - "*"
+  - apiGroups:
+      - pipelinesascode.tekton.dev
+    resources:
+      - repositories
     verbs:
       - "*"
   - nonResourceURLs:
       - "*"
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection


### PR DESCRIPTION
#### This PR is intended to make Roles/ClusterRoles defined in the repository more specific wrt the privileges required by the subjects:

    - minimizing use of wildcard characters
    - defining verbs a/c to specific need of the privileges on a resource under APIGroup.

Note: The redefined role for pipeline-service-manager is based on the privileges required by it to create the kcp-syncer generated manifests. 

Closes #213 

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>