### PR TITLE
PLNSRVCE-812 : define Pod and container securityContext and SCCs

### DIFF
--- a/operator/gitops/argocd/tekton-chains/base/chains-controller-deployment.yaml
+++ b/operator/gitops/argocd/tekton-chains/base/chains-controller-deployment.yaml
@@ -14,6 +14,25 @@ spec:
             # Mount the secrets volume
             - mountPath: /etc/ssl/certs
               name: chains-ca-cert
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            # User 65532 is the nonroot user ID
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 500m
+              memory: 500Mi
       volumes:
         - name: chains-ca-cert
           secret:

--- a/operator/gitops/argocd/tekton-results/deployment.yaml
+++ b/operator/gitops/argocd/tekton-results/deployment.yaml
@@ -51,6 +51,25 @@ spec:
             - name: config
               mountPath: /config/env
               readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            # User 65532 is the nonroot user ID
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 500m
+              memory: 500Mi
       serviceAccountName: tekton-results-api
       volumes:
         - name: tls
@@ -98,6 +117,25 @@ spec:
             - mountPath: /etc/tls
               name: tls
               readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            # User 65532 is the nonroot user ID
+            runAsUser: 65533
+            runAsGroup: 65532
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 500m
+              memory: 500Mi
       serviceAccountName: tekton-results-watcher
       volumes:
         - name: tls


### PR DESCRIPTION
With this PR, we add more configurations to deployment manifests to follow operator security standards.
    - define SCC
    - drop all capabilities
    - run as non-root user
    - resource requests and limits
    - readOnlyRootFileSystem

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>