### PR TITLE
fix typo in resource name while defining role for `pipeline-service-manager`

### DIFF
--- a/operator/gitops/compute/pipeline-service-manager/role.yaml
+++ b/operator/gitops/compute/pipeline-service-manager/role.yaml
@@ -41,7 +41,7 @@ rules:
   - apiGroups:
       - networking.k8s.io
     resources:
-      - ingress
+      - ingresses
       - networkpolicies
     verbs:
       - "*"


### PR DESCRIPTION

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>