### PR TITLE
Improve dependencies management

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -36,7 +36,11 @@
 | tkn                | see [dependencies.sh](shared/config/dependencies.sh) | To interact with tekton                                                     | |
 | tkn pac plugin     | 0.10.0                                               | To set up PaC                                                               | Optional plugin for customers during the cluster setup phase. Follows PaC Version |
 | Argo CD (client)   | see [dependencies.sh](shared/config/dependencies.sh) | To run Argo CD related commands                                             | Follows version of argocd engine used in openshift gitops |
+| checkov            | see [dependencies.sh](shared/config/dependencies.sh) | Validate k8s manifests                                                      | |
+| hadolint           | see [dependencies.sh](shared/config/dependencies.sh) | Validate Dockerfiles                                                        | |
+| shellcheck         | see [dependencies.sh](shared/config/dependencies.sh) | Validate shell scripts | |
 | skopeo             | 1.y.z                                                | Interact with images                                                        | |
+| yamllint           | see [dependencies.sh](shared/config/dependencies.sh) | Validate YAML                                                               | |
 | yq                 | see [dependencies.sh](shared/config/dependencies.sh) | Required for parsing things; used in various scripts throughout the project | Certain features are not supported with versions < 4.18.1. Use Latest version to avoid any issues |
 | docker             | 20.10.z                                              | For local development only                                                  | Only one of docker or podman is required. No requirement to use a particular version; users can install the latest version available at the time |
 | podman             | 4.0.0                                                | For local development only                                                  | Only one of docker or podman is required. No requirement to use a particular version; users can install the latest version available at the time |

--- a/developer/images/devenv/Dockerfile
+++ b/developer/images/devenv/Dockerfile
@@ -1,13 +1,23 @@
+#@FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:4ed971a5564d2cfedf750793da53ef6f1fdf295263f1cc31d703aa8acf6d02cf AS grpc_cli
+RUN set -x \
+    && microdnf install -y \
+        cmake-3.20.2 \
+        gcc-c++-8.5.0 \
+        git-2.31.1 \
+        libtool-2.4.6 \
+    && microdnf clean all
+COPY shared /tmp/image-build/shared
+RUN /tmp/image-build/shared/hack/install.sh --debug --bin grpc_cli
+
+
 FROM quay.io/podman/stable:v4.2.1
 
 RUN set -x \
     && mkdir ~/.kube \
     && mkdir -p /tmp/image-build \
     && dnf install -y \
-        cmake-3.22.2 \
-        gcc-c++-12.0.1 \
         git-2.38.1 \
-        libtool-2.4.6 \
         openssl-3.0.2 \
         procps-ng-3.3.17 \
         python3-pip-21.3.1 \
@@ -17,8 +27,8 @@ RUN set -x \
     && dnf clean all
 
 COPY shared /tmp/image-build/shared
-
-RUN /tmp/image-build/shared/hack/install.sh --debug --bin argocd,bitwarden,grpc_cli,hadolint,jq,kind,kubectl,oc,shellcheck,tkn,yamllint,yq \
+COPY --from=grpc_cli /usr/local/bin/grpc_cli /usr/local/bin/
+RUN /tmp/image-build/shared/hack/install.sh --debug --bin argocd,bitwarden,checkov,hadolint,jq,kind,kubectl,oc,shellcheck,tkn,yamllint,yq \
     && rm -rf /tmp/image-build
 
 WORKDIR "/workspace"

--- a/shared/config/dependencies.sh
+++ b/shared/config/dependencies.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 export ARGOCD_VERSION="v2.4.5"
+export BITWARDEN_VERSION="v2022.10.0"
+export CHECKOV_VERSION="2.2.112"
 export GRPC_CLI_VERSION="v1.50.0"
 export HADOLINT_VERSION="v2.10.0"
 export JQ_VERSION="1.6"
@@ -10,4 +12,3 @@ export SHELLCHECK_VERSION="v0.8.0"
 export TEKTONCD_CLI_VERSION="v0.27.0"
 export YAMLLINT_VERSION="1.28.0"
 export YQ_VERSION="v4.28.1"
-export BITWARDEN_VERSION="v2022.10.0"

--- a/shared/hack/install.sh
+++ b/shared/hack/install.sh
@@ -140,6 +140,11 @@ install_bitwarden() {
     bw --version
 }
 
+install_checkov() {
+    pip3 install --no-cache-dir checkov=="${CHECKOV_VERSION}"
+    checkov --version
+}
+
 install_grpc_cli() {
     # Build from code
     git clone https://github.com/grpc/grpc.git


### PR DESCRIPTION
- Add checkov, shellcheck, yamllint to the documented dependencies
- Add checkov to install.sh
- Uses multi-stage builds for grpc-cli

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>