### PR TITLE
Fix build of devenv failing on checkov

### DIFF
--- a/developer/images/devenv/Dockerfile
+++ b/developer/images/devenv/Dockerfile
@@ -1,9 +1,9 @@
-#@FROM registry.access.redhat.com/ubi8/ubi-minimal
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:4ed971a5564d2cfedf750793da53ef6f1fdf295263f1cc31d703aa8acf6d02cf AS grpc_cli
+#@FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:3685c58885771d2ea14608caeab6a4c3949b973588c29ce91f462b486ee1be25 AS grpc_cli
 RUN set -x \
     && microdnf install -y \
         cmake-3.20.2 \
-        gcc-c++-8.5.0 \
+        gcc-c++-11.3.1 \
         git-2.31.1 \
         libtool-2.4.6 \
     && microdnf clean all
@@ -11,24 +11,26 @@ COPY shared /tmp/image-build/shared
 RUN /tmp/image-build/shared/hack/install.sh --debug --bin grpc_cli
 
 
-FROM quay.io/podman/stable:v4.2.1
 
+FROM quay.io/podman/stable:v4.3.0
 RUN set -x \
     && mkdir ~/.kube \
     && mkdir -p /tmp/image-build \
     && dnf install -y \
+        # gcc is needed when installing checkov's dependencies
+        gcc-c++-12.2.1 \
         git-2.38.1 \
-        openssl-3.0.2 \
+        openssl-3.0.5 \
         procps-ng-3.3.17 \
-        python3-pip-21.3.1 \
+        # python3-devl is needed when installing checkov's dependencies
+        python3-devel-3.11.0 \
+        python3-pip-22.2.2 \
         unzip-6.0 \
         which-2.21 \
         xz-5.2.5 \
     && dnf clean all
-
-COPY shared /tmp/image-build/shared
 COPY --from=grpc_cli /usr/local/bin/grpc_cli /usr/local/bin/
+COPY shared /tmp/image-build/shared
 RUN /tmp/image-build/shared/hack/install.sh --debug --bin argocd,bitwarden,checkov,hadolint,jq,kind,kubectl,oc,shellcheck,tkn,yamllint,yq \
     && rm -rf /tmp/image-build
-
 WORKDIR "/workspace"

--- a/shared/config/dependencies.sh
+++ b/shared/config/dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 export ARGOCD_VERSION="v2.4.5"
 export BITWARDEN_VERSION="v2022.10.0"
-export CHECKOV_VERSION="2.2.112"
+export CHECKOV_VERSION="2.2.130"
 export GRPC_CLI_VERSION="v1.50.0"
 export HADOLINT_VERSION="v2.10.0"
 export JQ_VERSION="1.6"


### PR DESCRIPTION
An update in one of checkov's dependencies broke the install. Upgrading to a newer version is required to solve the problem.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>