### PR TITLE
Upgrade base images from ubi8 to ubi9

### DIFF
--- a/.tekton/pipeline-service-test.yaml
+++ b/.tekton/pipeline-service-test.yaml
@@ -37,7 +37,7 @@ spec:
               description: Openshift cluster name
           steps:
             - name: cluster-name
-              image: registry.access.redhat.com/ubi8/openssl:8.6-32
+              image: registry.access.redhat.com/ubi9/openssl:9.1-2
               script: |
                 #!/usr/bin/env bash
                 CLUSTER_NAME="ci-$( openssl rand -hex 5 )"

--- a/ci/images/quay-upload/Dockerfile
+++ b/ci/images/quay-upload/Dockerfile
@@ -1,5 +1,5 @@
-#@FROM registry.access.redhat.com/ubi8/ubi-minimal
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:6910799b75ad41f00891978575a0d955be2f800c51b955af73926e7ab59a41c3
+#@FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:3685c58885771d2ea14608caeab6a4c3949b973588c29ce91f462b486ee1be25
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides binaries and a script to tag images with the latest commit ID on quay.io" \

--- a/ci/images/vulnerability-scan/Dockerfile
+++ b/ci/images/vulnerability-scan/Dockerfile
@@ -1,5 +1,5 @@
-#@FROM registry.access.redhat.com/ubi8/ubi-minimal
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:6910799b75ad41f00891978575a0d955be2f800c51b955af73926e7ab59a41c3
+#@FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:3685c58885771d2ea14608caeab6a4c3949b973588c29ce91f462b486ee1be25
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides a script to scan Clair for security vulnerabilities on container images via Quay." \

--- a/operator/images/access-setup/Dockerfile
+++ b/operator/images/access-setup/Dockerfile
@@ -1,11 +1,14 @@
-#@FROM registry.access.redhat.com/ubi8/ubi-minimal
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:6910799b75ad41f00891978575a0d955be2f800c51b955af73926e7ab59a41c3
+#@FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:3685c58885771d2ea14608caeab6a4c3949b973588c29ce91f462b486ee1be25
 WORKDIR /
 RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
 ENV HOME /tmp/home
 RUN mkdir $HOME && chmod 777 $HOME && chown 65532:65532 $HOME
 
-RUN microdnf install -y gzip-1.9 tar-1.30 && microdnf clean all
+RUN microdnf install -y \
+      gzip-1.12 \
+      tar-1.34 \
+    && microdnf clean all
 
 COPY shared /tmp/image-build/shared
 WORKDIR /tmp/image-build/shared/hack

--- a/operator/images/cluster-setup/Dockerfile
+++ b/operator/images/cluster-setup/Dockerfile
@@ -1,5 +1,5 @@
-#@FROM registry.access.redhat.com/ubi8/ubi-minimal
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:6910799b75ad41f00891978575a0d955be2f800c51b955af73926e7ab59a41c3
+#@FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:3685c58885771d2ea14608caeab6a4c3949b973588c29ce91f462b486ee1be25
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides binaries and a script to install tektoncd components on the workload clusters." \
@@ -17,7 +17,11 @@ LABEL build-date= \
       version="0.1"
 WORKDIR /
 RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
-RUN microdnf install -y findutils-4.6.0 git-2.31.1  unzip-6.0 && microdnf clean all
+RUN microdnf install -y \
+      findutils-4.8.0 \
+      git-2.31.1 \
+      unzip-6.0 \
+    && microdnf clean all
 
 COPY shared /tmp/image-build/shared
 RUN /tmp/image-build/shared/hack/install.sh --bin bitwarden,jq,kubectl,yq \

--- a/operator/images/update-pipeline-service/Dockerfile
+++ b/operator/images/update-pipeline-service/Dockerfile
@@ -1,5 +1,5 @@
-#@FROM registry.access.redhat.com/ubi8/ubi-minimal
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:6910799b75ad41f00891978575a0d955be2f800c51b955af73926e7ab59a41c3
+#@FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:3685c58885771d2ea14608caeab6a4c3949b973588c29ce91f462b486ee1be25
 LABEL build-date= \
       com.redhat.build-host= \
       description="This image provides the required tooling to update the image tags on the SRE gitops repository" \

--- a/operator/test/test.sh
+++ b/operator/test/test.sh
@@ -112,9 +112,14 @@ test_pipelines() {
   BASE_URL="https://raw.githubusercontent.com/tektoncd/pipeline/v0.32.0"
   manifest="pipelineruns/using_context_variables.yaml"
   # change ubuntu image to ubi to avoid dockerhub registry pull limit
-  PIPELINE_RUN=$(curl --fail --silent "$BASE_URL/examples/v1beta1/$manifest" | sed 's|ubuntu|registry.access.redhat.com/ubi8/ubi-minimal:latest|' | sed '/serviceAccountName/d' | kubectl create -n $PIPELINES_NS -f -)
+  PIPELINE_RUN=$(
+    curl --fail --silent "$BASE_URL/examples/v1beta1/$manifest" |
+      sed 's|ubuntu|registry.access.redhat.com/ubi9/ubi-minimal:latest|' |
+      sed '/serviceAccountName/d' |
+      kubectl create -n $PIPELINES_NS -f -
+  )
   echo "$PIPELINE_RUN"
-  
+
   kubectl wait --for=condition=Succeeded  -n $PIPELINES_NS PipelineRun --all --timeout=60s >/dev/null
   echo "Print pipelines"
   kubectl get -n $PIPELINES_NS pipelineruns


### PR DESCRIPTION
This fixes a vulnerability on python-pip introduced by the git package.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>