### PR TITLE
Fix broken tekton-chains test

### DIFF
--- a/operator/test/manifests/test/tekton-chains/simple-copy-pipeline.yaml
+++ b/operator/test/manifests/test/tekton-chains/simple-copy-pipeline.yaml
@@ -26,15 +26,20 @@ spec:
           Task to copy a container image from a container repository to another.
         params:
           - name: IMAGE_SRC
-            description: Reference of the image buildah will pull.
+            description: Reference of the image skopeo will pull.
           - name: IMAGE_DST
-            description: Reference of the image buildah will push.
-          - name: BUILDER_IMAGE
-            description: The location of the buildah builder image.
-            default: quay.io/buildah/stable:v1.18.0
-        workspaces:
-          - name: sslcertdir
-            optional: true
+            description: Reference of the image skopeo will push.
+          - name: SKOPEO_IMAGE
+            description: The location of the skopeo image.
+            default: quay.io/skopeo/stable:v1.9.0
+          - name: srcTLSverify
+            description: Verify the TLS on the src registry endpoint
+            type: string
+            default: "true"
+          - name: destTLSverify
+            description: Verify the TLS on the dest registry endpoint
+            type: string
+            default: "true"
         results:
           - name: IMAGE_DIGEST
             description: Digest of the image just built.
@@ -42,28 +47,26 @@ spec:
             description: Reference of the image the pipeline will produce.
         steps:
           - name: copy
-            image: $(params.BUILDER_IMAGE)
+            env:
+              - name: HOME
+                value: /tekton/home
+            image: $(params.SKOPEO_IMAGE)
             script: |
-              [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
-              echo "# Pulling image from: $(params.IMAGE_SRC)"
-              buildah \
-                ${CERT_DIR_FLAG} \
-                pull \
-                $(params.IMAGE_SRC)
-              echo "# Pushing image to: $(params.IMAGE_DST)"
-              buildah \
-                ${CERT_DIR_FLAG} \
-                push \
-                --digestfile /tmp/image-digest \
-                $(params.IMAGE_SRC) docker://$(params.IMAGE_DST)
-              cat "/tmp/image-digest" | tee $(results.IMAGE_DIGEST.path)
-              echo "$(params.IMAGE_DST)" | tee $(results.IMAGE_URL.path)
-            volumeMounts:
-              - name: varlibcontainers
-                mountPath: /var/lib/containers
-        volumes:
-          - name: varlibcontainers
-            emptyDir: {}
+              set -o errexit
+              set -o pipefail
+              if [ "$(params.IMAGE_SRC)" != "" ] && [ "$(params.IMAGE_DST)" != "" ] ; then
+                skopeo copy \
+                  docker://"$(params.IMAGE_SRC)" docker://"$(params.IMAGE_DST)" \
+                   --digestfile /tmp/image-digest \
+                   --src-tls-verify="$(params.srcTLSverify)" \
+                   --dest-tls-verify="$(params.destTLSverify)"
+                echo "$(params.IMAGE_DST)" > "$(results.IMAGE_URL.path)"
+                cat "/tmp/image-digest" > "$(results.IMAGE_DIGEST.path)"
+              else
+                return 1
+              fi
+            securityContext:
+              runAsNonRoot: true
       params:
         - name: IMAGE_SRC
           value: $(params.image-src)

--- a/operator/test/test.sh
+++ b/operator/test/test.sh
@@ -44,8 +44,7 @@ test_chains() {
   kubectl apply -k "$SCRIPT_DIR/manifests/test/tekton-chains" -n "$ns"
 
   # Wait for pipelines to set up all the components
-  while [ "$(kubectl get applications -n openshift-gitops tekton-chains -o json | jq -r ".status.sync.status")" != "Synced" ] || \
-    [ "$(kubectl get serviceaccounts -n test-tekton-chains | grep -cE "^pipeline ")" != "1" ]; do
+  while [ "$(kubectl get serviceaccounts -n test-tekton-chains | grep -cE "^pipeline ")" != "1" ]; do
     echo -n "."
     sleep 2
   done


### PR DESCRIPTION
 Fix broken tekton-chains test   
    - use Skopeo instead of Buildah in the Pipeline example manifest to copy image.
    - remove checks for argo tekton-chains app since it's no more deployed as an argo-app.

#### How to test
Do a `KUBECONFIG=~/.kube/config CASES=chains ./operator/test/test.sh` once Pipeline-Service is deployed on the cluster.

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>