### PR TITLE
Add required permission for argocd to delete pipeline-service application

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/allow-argocd-to-manage.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/allow-argocd-to-manage.yaml
@@ -12,6 +12,8 @@ rules:
       - get
       - list
       - patch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/operator/gitops/argocd/pipeline-service/pipelines-as-code/allow-argocd.yaml
+++ b/operator/gitops/argocd/pipeline-service/pipelines-as-code/allow-argocd.yaml
@@ -19,6 +19,7 @@ rules:
       - validatingwebhookconfigurations
     verbs:
       - create
+      - delete
   - apiGroups:
       - monitoring.coreos.com
     resources:


### PR DESCRIPTION

In order to delete pipeline-service application, argocd requires permission to delete cluster resources that has been created (tektonconfigs, validatingwebhookconfigurations)