### PR TITLE
Fix and enable tekton-chains test in CI

### DIFF
--- a/.tekton/pipeline-service-test.yaml
+++ b/.tekton/pipeline-service-test.yaml
@@ -317,7 +317,7 @@ spec:
 
                 echo "Start executing pipeline cases ..."
                 TEST_DIR=$(find "$PWD" -type f -name test.sh -exec dirname {} +)
-                KUBECONFIG=/kubeconfig CASES=pipelines $TEST_DIR/test.sh
+                KUBECONFIG=/kubeconfig CASES=pipelines,chains $TEST_DIR/test.sh
                 EOF
 
                 chmod +x plnsvc_test.sh

--- a/operator/test/manifests/test/tekton-chains/simple-copy-pipeline.yaml
+++ b/operator/test/manifests/test/tekton-chains/simple-copy-pipeline.yaml
@@ -67,6 +67,7 @@ spec:
               fi
             securityContext:
               runAsNonRoot: true
+              runAsUser: 65532
       params:
         - name: IMAGE_SRC
           value: $(params.image-src)


### PR DESCRIPTION
When using runAsNonRoot we need one of the following:
- Use the `USER` directive in Dockerfile to specify a non root user
- use the `runAsUser` in kubernetes SecurityContext. 
In the case of tekton-chains test the used image does not specify a non root USER so `runAsUser` is required.