### PR TITLE
Miscellaneous fixes to deployment scripts

### DIFF
--- a/developer/openshift/dev_setup.sh
+++ b/developer/openshift/dev_setup.sh
@@ -78,7 +78,7 @@ parse_args() {
 precheck_binary() {
   for binary in "$@"; do
     command -v "$binary" >/dev/null 2>&1 || {
-      echo >&2 "openshift_dev_setup.sh requires '$binary' command-line utility to be installed on your local machine. Aborting..."
+      echo "[ERROR] This script requires '$binary' to be installed on your local machine." >&2
       exit 1
     }
   done
@@ -119,7 +119,7 @@ init() {
 check_cluster_role() {
   if [ "$(kubectl auth can-i '*' '*' --all-namespaces)" != "yes" ]; then
     echo
-    echo "[ERROR] User '$(oc whoami)' does not have the required 'cluster-admin' role." 1>&2
+    echo "[ERROR] User '$(oc whoami)' does not have the required 'cluster-admin' role." >&2
     echo "Log into the cluster with a user with the required privileges (e.g. kubeadmin) and retry."
     exit 1
   fi
@@ -203,7 +203,7 @@ install_pipeline_service() {
 
 main() {
   parse_args "$@"
-  precheck_binary "kubectl" "yq" "curl" "argocd"
+  precheck_binary "curl" "argocd" "kubectl" "yq"
   init
   check_cluster_role
   echo "[compute-access]"

--- a/operator/images/access-setup/content/bin/setup_work_dir.sh
+++ b/operator/images/access-setup/content/bin/setup_work_dir.sh
@@ -80,12 +80,14 @@ parse_args() {
   done
 }
 
-prechecks(){
-  # Check that argocd has been installed
-  if [[ $(kubectl api-resources | grep -c "argoproj.io/") = "0" ]]; then
-    echo "Argo CD must be deployed on the cluster first" >&2
-    exit 1
-  fi
+# Checks if a binary is present on the local system
+precheck_binary() {
+  for binary in "$@"; do
+    command -v "$binary" >/dev/null 2>&1 || {
+      echo "[ERROR] This script requires '$binary' to be installed on your local machine." >&2
+      exit 1
+    }
+  done
 }
 
 init() {
@@ -196,7 +198,7 @@ tekton_results_manifest(){
 
 main() {
   parse_args "$@"
-  prechecks
+  precheck_binary "kubectl" "yq"
   init
   generate_shared_manifests
   configure_argocd_apps

--- a/operator/images/cluster-setup/content/bin/install.sh
+++ b/operator/images/cluster-setup/content/bin/install.sh
@@ -108,6 +108,12 @@ switch_cluster() {
   if ! kubectl config use-context "${contexts[$i]}" >/dev/null; then
     exit_error "\nCannot use '${contexts[$i]}' context in '$KUBECONFIG'."
   fi
+
+  # Check that argocd has been installed
+  if [[ $(kubectl api-resources | grep -c "argoproj.io/") = "0" ]]; then
+    echo "[ERROR] Argo CD must be deployed on the cluster for kubeconfig/context: '${kubeconfigs[$i]}'/'${contexts[$i]}'" >&2
+    exit 1
+  fi
 }
 
 install_clusters() {


### PR DESCRIPTION
- Cosmetic changes to developer/openshift/dev_setup.sh
- Add binary check to operator/images/access-setup/content/bin/setup_work_dir.sh
- Move ArgoCD installation check from operator/images/access-setup/content/bin/setup_work_dir.sh to operator/test/manifests/test/tekton-chains/simple-copy-pipeline.yaml

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>