### PR TITLE
Automatically create tekton-results-database-secret

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/deployment.yaml
@@ -24,6 +24,18 @@ spec:
         app.kubernetes.io/part-of: tekton-results
         app.kubernetes.io/version: v0.4.0
     spec:
+      initContainers:
+        - name: create-tekton-results-database-secret
+          image: quay.io/openshift/origin-cli:4.11
+          command:
+            - /bin/bash
+            - -c
+            - |
+              if oc get secret -n tekton-results tekton-results-database 2>&1 >/dev/null; then exit; fi
+              oc create secret generic tekton-results-database \
+                --namespace="tekton-results" \
+                --from-literal=DATABASE_USER=tekton \
+                --from-literal=DATABASE_PASSWORD=$(dd if=/dev/urandom bs=20 count=1 2>/dev/null | base64)
       containers:
         - env:
             - name: DB_USER

--- a/operator/gitops/argocd/pipeline-service/tekton-results/permissions.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/permissions.yaml
@@ -39,6 +39,13 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
tekton-results-database-secret is now automatically created via an initcontainer instead of relying on a manual or scripted action for this secret.