### PR TITLE
PLNSRVCE-1000: fix `ckv_docker` errors reported by checkov

### DIFF
--- a/ci/images/ci-runner/Dockerfile
+++ b/ci/images/ci-runner/Dockerfile
@@ -31,4 +31,5 @@ COPY --from=grpc_cli /usr/local/bin/grpc_cli /usr/local/bin/
 COPY shared /tmp/image-build/shared
 RUN /tmp/image-build/shared/hack/install.sh --debug --bin argocd,go,jq,kubectl,tkn,yq \
     && rm -rf /tmp/image-build
+USER 65532:65532
 WORKDIR "/source"

--- a/ci/images/static-checks/content/config/checkov.yaml
+++ b/ci/images/static-checks/content/config/checkov.yaml
@@ -10,6 +10,8 @@ framework:
 skip-download: false
 output: cli
 quiet: true
-skip-check: []
+skip-check:
+  # skip HEALTHCHECK instructions check
+  - CKV_DOCKER_2
 skip-fixes: true
 soft-fail: true

--- a/developer/images/devenv/Dockerfile
+++ b/developer/images/devenv/Dockerfile
@@ -33,4 +33,5 @@ COPY --from=grpc_cli /usr/local/bin/grpc_cli /usr/local/bin/
 COPY shared /tmp/image-build/shared
 RUN /tmp/image-build/shared/hack/install.sh --debug --bin argocd,bitwarden,checkov,hadolint,jq,kind,kubectl,oc,shellcheck,tkn,yamllint,yq \
     && rm -rf /tmp/image-build
+USER 65532:65532
 WORKDIR "/workspace"


### PR DESCRIPTION
fix `ckv_docker` errors reported by checkov  
    - fix `ckv_docker_3` issues
    - ignore `ckv_docker_2` issues reported for Healthcheck inside
      Docker containers

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>