### PR TITLE
Revert "fix `ckv_docker` errors reported by checkov"

### DIFF
--- a/ci/images/ci-runner/Dockerfile
+++ b/ci/images/ci-runner/Dockerfile
@@ -31,5 +31,4 @@ COPY --from=grpc_cli /usr/local/bin/grpc_cli /usr/local/bin/
 COPY shared /tmp/image-build/shared
 RUN /tmp/image-build/shared/hack/install.sh --debug --bin argocd,go,jq,kubectl,tkn,yq \
     && rm -rf /tmp/image-build
-USER 65532:65532
 WORKDIR "/source"

--- a/ci/images/static-checks/content/config/checkov.yaml
+++ b/ci/images/static-checks/content/config/checkov.yaml
@@ -10,8 +10,6 @@ framework:
 skip-download: false
 output: cli
 quiet: true
-skip-check:
-  # skip HEALTHCHECK instructions check
-  - CKV_DOCKER_2
+skip-check: []
 skip-fixes: true
 soft-fail: true

--- a/developer/images/devenv/Dockerfile
+++ b/developer/images/devenv/Dockerfile
@@ -33,5 +33,4 @@ COPY --from=grpc_cli /usr/local/bin/grpc_cli /usr/local/bin/
 COPY shared /tmp/image-build/shared
 RUN /tmp/image-build/shared/hack/install.sh --debug --bin argocd,bitwarden,checkov,hadolint,jq,kind,kubectl,oc,shellcheck,tkn,yamllint,yq \
     && rm -rf /tmp/image-build
-USER 65532:65532
 WORKDIR "/workspace"


### PR DESCRIPTION
This reverts commit a0e6a1a409d9f690f993ca4c596b37f3f4ceb205.

Caused

```
+ podman run --rm --env COSIGN_PASSWORD=dIsmAfF3VRRMLtkU --volume /tmp/tmp.4MDvmF5mi3/credentials/manifests/compute/tekton-chains/tmp:/workspace:z --workdir /workspace --entrypoint /usr/bin/cosign quay.io/redhat-appstudio/appstudio-utils:eb94f28fe2d7c182f15e659d0fdb66f87b0b3b6b generate-key-pair
        Error: crun: writing file `/proc/947/setgroups`: Operation not permitted: OCI permission denied
command terminated with exit code 126
```