### PR TITLE
Remove tekton-chains resource limits

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-chains/chains-controller-deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/chains-controller-deployment.yaml
@@ -43,13 +43,6 @@ spec:
             seccompProfile:
               type: RuntimeDefault
             readOnlyRootFilesystem: true
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-            limits:
-              cpu: 500m
-              memory: 500Mi
       volumes:
         - name: chains-ca-cert
           secret:


### PR DESCRIPTION
Resource limits of tekton-chains are not tailored to stonesoup staging cluster usage, making the controller OOMKilled. They have been removed for now until we set the correct numbers next.