### PR TITLE
[WIP] add helm to allow for helm based install of the minio operator

### DIFF
--- a/ci/images/ci-runner/Dockerfile
+++ b/ci/images/ci-runner/Dockerfile
@@ -27,6 +27,13 @@ RUN set -x \
         tar-2:1.34 \
         xz-5.2.5 \
     && microdnf clean all
+#Installing helm as part of a work around for installing the minio operator while we sort out stale operator hub catalogs with hypershift.
+#Once that has been sorted out (check with Adam), the minio requirement for helm will go away.
+#NOTE: while newer versions of fedora allow dnf installation of helm, the ubi9 minimal image we have here does not.
+RUN set -x \
+    && mkdir -p /usr/local/bin \
+    && curl -L https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64 -o /usr/local/bin/helm \
+    && chmod +x /usr/local/bin/helm
 COPY --from=grpc_cli /usr/local/bin/grpc_cli /usr/local/bin/
 COPY shared /tmp/image-build/shared
 RUN /tmp/image-build/shared/hack/install.sh --debug --bin argocd,go,jq,kubectl,tkn,yq \

--- a/developer/images/devenv/Dockerfile
+++ b/developer/images/devenv/Dockerfile
@@ -28,7 +28,14 @@ RUN set -x \
         unzip-6.0 \
         which-2.21 \
         xz-5.2.5 \
-    && dnf clean all
+    && dnf clean all \
+#Installing helm as part of a work around for installing the minio operator while we sort out stale operator hub catalogs with hypershift.
+#Once that has been sorted out (check with Adam), the minio requirement for helm will go away.
+#NOTE: while newer versions of fedora allow dnf installation of helm, the ubi9 minimal image we have here does not.
+RUN set -x \
+    && mkdir -p /usr/local/bin \
+    && curl -L https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64 -o /usr/local/bin/helm \
+    && chmod +x /usr/local/bin/helm
 COPY --from=grpc_cli /usr/local/bin/grpc_cli /usr/local/bin/
 COPY shared /tmp/image-build/shared
 RUN /tmp/image-build/shared/hack/install.sh --debug --bin argocd,bitwarden,checkov,hadolint,jq,kind,kubectl,oc,shellcheck,tkn,yamllint,yq \


### PR DESCRIPTION
This is the enable install of the minio operator via `helm`

We are exploring that approach as a short (hopefully) workaround for the hypershift operator hub catalogs are out of date.  @adambkaplan is taking on pursuing that issue with the requisite teams separately.

See https://github.com/openshift-pipelines/pipeline-service/pull/443 for why this is a concern for getting minio in.

Next, marked as WIP for now given the conversation over in https://redhat-internal.slack.com/archives/C032EJ007C0/p1674487220868799 with @Roming22 and the infra team

Lastly, doing this in a separate PR than https://github.com/openshift-pipelines/pipeline-service/pull/443  since we have the issue where image update from a PR are not available in the PR.  The CI tests are currently hard coded to use the `main` tag of the images.

If / once this merges, I'll update #443 to use helm to install 4.5.8 of the minio operator.

The successful bit from building with these changes on my local system:

```
---> 79a8984b8a11
Step 7/11 : RUN set -x     && mkdir -p /usr/local/bin     && curl -L https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64 -o /usr/local/bin/helm     && chmod +x /usr/local/bin/helm
 ---> Running in ffe4be9227f4
+ mkdir -p /usr/local/bin
+ curl -L https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64 -o /usr/local/bin/helm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 44.1M  100 44.1M    0     0  2904k      0  0:00:15  0:00:15 --:--:-- 6515k
+ chmod +x /usr/local/bin/helm
Removing intermediate container ffe4be9227f4
 ---> e81ab88902fd
```