### PR TITLE
Increase pruner frequency to every 2 minutes

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -17,6 +17,6 @@ spec:
     keep: 10
     resources:
       - pipelinerun
-    schedule: 0/10 * * * *
+    schedule: 0/2 * * * *
   profile: all
   targetNamespace: openshift-pipelines


### PR DESCRIPTION
Until tekton-results prunes the pipelines as soon as the logs have been stored, we need to be more aggressive in the pruning to prevent users running into PVCs quota issues.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>