### PR TITLE
Add rsync to ci-runner image

### DIFF
--- a/ci/images/ci-runner/Dockerfile
+++ b/ci/images/ci-runner/Dockerfile
@@ -23,6 +23,7 @@ RUN set -x \
         podman-2:4.2.0 \
         procps-ng-3.3.17 \
         python3-pip-21.2.3 \
+        rsync-3.2.3 \
         unzip-6.0 \
         tar-2:1.34 \
         xz-5.2.5 \


### PR DESCRIPTION
This is required for the minio commit to pass the CI

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>