### PR TITLE
Add gettext to ci-runner image

### DIFF
--- a/ci/images/ci-runner/Dockerfile
+++ b/ci/images/ci-runner/Dockerfile
@@ -17,6 +17,7 @@ RUN set -x \
     && mkdir ~/.kube \
     && mkdir -p /tmp/image-build \
     && microdnf install -y \
+        gettext-0.21 \
         git-2.31.1 \
         findutils-1:4.8.0 \
         openssl-3.0.1 \


### PR DESCRIPTION
This is required for the minio commit to pass the CI, as it requires envsubst

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>