### PR TITLE
Create signing-secret early in the deployment

### DIFF
--- a/ci/images/ci-runner/hack/sidecar/bin/plnsvc_test.sh
+++ b/ci/images/ci-runner/hack/sidecar/bin/plnsvc_test.sh
@@ -6,4 +6,4 @@ set -x
 
 echo "Start executing pipeline cases ..."
 TEST_DIR=$(find "$PWD" -type f -name test.sh -exec dirname {} +)
-KUBECONFIG=/kubeconfig CASES=pipelines "$TEST_DIR/test.sh"
+KUBECONFIG=/kubeconfig CASES=pipelines,chains "$TEST_DIR/test.sh"

--- a/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-config.yaml
@@ -122,7 +122,7 @@ metadata:
   name: tekton-chains-signing-secret
   namespace: tekton-chains
   annotations:
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook: Sync
 spec:
   template:
     spec:


### PR DESCRIPTION
This fixes an issues when deploying where the tekton-chains controller was failing because it did not have access to the secret.