### PR TITLE
Use source branch for ci

### DIFF
--- a/ci/images/ci-runner/hack/sidecar/bin/plnsvc_setup.sh
+++ b/ci/images/ci-runner/hack/sidecar/bin/plnsvc_setup.sh
@@ -15,4 +15,4 @@ echo "Start executing pipeline-service setup ..."
 yq -i e ".git_url=\"$REPO_URL\"" "$CONFIG"
 yq -i e ".git_ref=\"$REPO_REVISION\"" "$CONFIG"
 
-"$OPENSHIFT_DIR/dev_setup.sh" --debug
+"$OPENSHIFT_DIR/dev_setup.sh" --debug --use-current-branch --force --work-dir "$OPENSHIFT_DIR/work"

--- a/developer/openshift/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - "github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/pipeline-service/openshift-pipelines?ref=main"
+  - ../../../../../../operator/gitops/argocd/pipeline-service/openshift-pipelines

--- a/developer/openshift/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - "github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/pipeline-service/pipelines-as-code?ref=main"
+  - ../../../../../../operator/gitops/argocd/pipeline-service/pipelines-as-code

--- a/developer/openshift/gitops/argocd/pipeline-service/tekton-chains/kustomization.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service/tekton-chains/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - "github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/pipeline-service/tekton-chains?ref=main"
+  - ../../../../../../operator/gitops/argocd/pipeline-service/tekton-chains

--- a/developer/openshift/gitops/argocd/pipeline-service/tekton-results/kustomization.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service/tekton-results/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - "github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/pipeline-service/tekton-results/base?ref=main"
+  - ../../../../../../operator/gitops/argocd/pipeline-service/tekton-results/base
 
 patchesStrategicMerge:
   - minio-tls-patch.yaml

--- a/operator/images/access-setup/content/bin/setup_work_dir.sh
+++ b/operator/images/access-setup/content/bin/setup_work_dir.sh
@@ -34,7 +34,8 @@ Setup working directory for Pipeline Service
 
 Optional arguments:
     --kustomization KUSTOMIZATION
-        path to the directory holding the kustomization.yaml to deploy Pipeline Service via ArgoCD.
+        path to the directory or manifest holding the configuration to deploy
+        Pipeline Service via ArgoCD.
         Can be read from \$KUSTOMIZATION.
         Default: %s
     -w, --work-dir WORK_DIR


### PR DESCRIPTION
Add an option to dev_setup.sh to deploy the current branch.
This option should make it easy to test the source branch in PRs.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>

Validation of the PR needs to happen in throw away PR #471.