### PR TITLE
Adding custom exporter code to pipeline service

### DIFF
--- a/operator/gitops/argocd/pipeline-service/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - pipelines-as-code
   - tekton-chains
   - tekton-results/base
+  - metrics-exporter
 
   # Skip applying the Tekton operands while the Tekton operator is being installed.
   # See more information about this option, here:

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrole.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrole.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pipeline-service-exporter-reader
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns", "taskruns"]
+    verbs: ["get", "list"]
+
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pipeline-metrics-exporter
+  namespace: pipeline-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pipeline-metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: pipeline-metrics-exporter
+    spec:
+      containers:
+        - name: pipeline-metrics-exporter
+          image: quay.io/redhat-pipeline-service/metrics-exporter:latest
+          ports:
+            - containerPort: 9117
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+      restartPolicy: Always

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+resources:
+  - clusterrole.yaml
+  - deployment.yaml
+  - service.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/service.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pipeline-metrics-exporter-service
+  namespace: pipeline-service
+spec:
+  selector:
+    app: pipeline-metrics-exporter
+  ports:
+    - name: metrics
+      path: /metrics
+      port: 9117
+      targetPort: 9117
+      protocol: TCP


### PR DESCRIPTION
- This PR makes the necessary changes to deploy the custom metrics exporter for Pipeline Service into Pipeline Service.
- The exporter code lives here - https://github.com/openshift-pipelines/pipeline-service-exporter 

This PR goes along with https://github.com/redhat-appstudio/infra-deployments/pull/1304 on infra-deployments.