### PR TITLE
fix a Dockerfile issue

### DIFF
--- a/developer/images/dependencies-update/Dockerfile
+++ b/developer/images/dependencies-update/Dockerfile
@@ -29,6 +29,7 @@ COPY shared /tmp/image-build/shared
 RUN /tmp/image-build/shared/hack/install.sh --debug --bin jq \
     && rm -rf /tmp/image-build
 
+COPY developer/images/dependencies-update/hack /opt/dependencies-update
 RUN chmod 755 /opt/dependencies-update/bin/*.sh
 USER 65532:65532
 ENV WORK_DIR /workspace


### PR DESCRIPTION
This PR is to fix an Dockerfile issue `cannot access '/opt/dependencies-update/bin/*.sh': No such file or directory`


Signed-off-by: Xin Jiang @xinredhat 
