### PR TITLE
Use custom service account for metrics deployment

### DIFF
--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrolebinding.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-pipeline-service-exporter-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pipeline-service-exporter-reader
+subjects:
+  - kind: ServiceAccount
+    name: pipeline-service-exporter
+    namespace: openshift-pipelines

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: pipeline-metrics-exporter
     spec:
-      serviceAccountName: prometheus-k8s
+      serviceAccountName: pipeline-service-exporter
       containers:
         - name: pipeline-metrics-exporter
           image: quay.io/redhat-pipeline-service/metrics-exporter:f008a14

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml
@@ -1,6 +1,8 @@
 ---
 resources:
+  - serviceaccount.yaml
   - clusterrole.yaml
+  - clusterrolebinding.yaml
   - deployment.yaml
   - service.yaml
 

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/serviceaccount.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline-service-exporter
+  namespace: openshift-pipelines


### PR DESCRIPTION
Local run:

```
[bnr@bnr pipeline-service]$ k -n openshift-pipelines get pods
NAME                                                 READY   STATUS        RESTARTS   AGE
pipeline-metrics-exporter-7c87c975bc-t2r5r           1/1     Running       0          33s

```

```
# HELP pipeline_service_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which pipeline_service_exporter was built.
# TYPE pipeline_service_exporter_build_info gauge
pipeline_service_exporter_build_info{branch="",goversion="go1.19.5",revision="",version=""} 1
# HELP pipelinerun_duration_completed_seconds Duration in seconds for a PipelineRun to complete.
# TYPE pipelinerun_duration_completed_seconds gauge
pipelinerun_duration_completed_seconds{name="pipelinerun-echo-greetings",uid="da686962-80de-413e-8ee8-34987b60c0ac"} 10
# HELP pipelinerun_duration_scheduled_seconds Duration in seconds for a PipelineRun to be scheduled.
# TYPE pipelinerun_duration_scheduled_seconds gauge
pipelinerun_duration_scheduled_seconds{name="pipelinerun-echo-greetings",uid="da686962-80de-413e-8ee8-34987b60c0ac"} 0
```