### PR TITLE
fix CKV_DOCKER errors

### DIFF
--- a/ci/images/static-checks/content/config/checkov.yaml
+++ b/ci/images/static-checks/content/config/checkov.yaml
@@ -10,6 +10,10 @@ framework:
 skip-download: false
 output: cli
 quiet: true
-skip-check: []
+skip-check:
+  # skip Healthcheck instruction error for Docker Images
+  - CKV_DOCKER_2
 skip-fixes: true
 soft-fail: true
+skip-path:
+  - developer


### PR DESCRIPTION
fix CKV_DOCKER errors 
  - ignore `developer` directory from Checkov scan
  - ignore Healthcheck instruction error for docker images