### PR TITLE
fix: bump chains-certs-configuration image version

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-config.yaml
@@ -82,7 +82,7 @@ spec:
   template:
     spec:
       containers:
-        - image: registry.redhat.io/openshift4/ose-cli:v4.11
+        - image: registry.redhat.io/openshift4/ose-cli:v4.12@sha256:9f0cdc00b1b1a3c17411e50653253b9f6bb5329ea4fb82ad983790a6dbf2d9ad
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
### What

This PR is required to fix the error that was found when trying to bootstrap stonesoup
```
Failed to pull image "registry.redhat.io/openshift4/ose-cli:v4.11": rpc error: code = Unknown desc = loading manifest for target platform: reading manifest sha256:836004f30587ffb184ee4681dd1c6d779e6703a18fd9a69b47c27f062fc28862 in registry.redhat.io/openshift4/ose-cli: unsupported: Not Found, or unsupported. V2 schema 1 manifest digest are no longer supported for image pulls. Use the equivalent schema 2 manifest digest instead. For more information see https://access.redhat.com/articles/6138332
```
The image version is based on a [fix that was merged recently](https://github.com/redhat-appstudio/build-definitions/pull/309/files) to fix build pipelines


### Verification

Verified the stonesoup bootstrap with [the branch from this PR](https://github.com/redhat-appstudio/infra-deployments/commit/2b073d26de4a23d75636e080c6f150da8cb56509)