### PR TITLE
PLNSRVCE-1111: CI: Test the upgrade path

### DIFF
--- a/.tekton/pipeline-service-upgrade-test.yaml
+++ b/.tekton/pipeline-service-upgrade-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: pipeline-service-test
+  name: pipeline-service-upgrade-test
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request, push]"
     pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/*]"
@@ -27,8 +27,20 @@ spec:
     workspaces:
       - name: source
       - name: kubeconfig-dir
-      - name: shared-workspace
+      - name: upgrade-shared-workspace
     tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+          kind: ClusterTask
+        workspaces:
+          - name: output
+            workspace: source
+        params:
+          - name: url
+            value: $(params.repo_url)
+          - name: revision
+            value: $(params.target_branch)
       - name: produce-cluster-name
         runAfter:
           - "fetch-repository"
@@ -47,47 +59,6 @@ spec:
                 set -x
                 CLUSTER_NAME="ci-$( openssl rand -hex 5 )"
                 echo -n "$CLUSTER_NAME" | tee $(results.cluster-name.path)
-      - name: clean-clusters
-        runAfter:
-          - "fetch-repository"
-        params:
-          - name: target_branch
-            value: $(params.target_branch)
-        workspaces:
-          - name: kubeconfig-dir
-            workspace: kubeconfig-dir
-          - name: source
-            workspace: source
-        taskSpec:
-          params:
-            - name: target_branch
-          workspaces:
-            - name: kubeconfig-dir
-            - name: source
-          kind: ClusterTask
-          steps:
-            - name: destroy-clusters
-              image: quay.io/redhat-pipeline-service/ci-runner:$(params.target_branch)
-              env:
-                - name: "KUBECONFIG"
-                  value: "$(workspaces.kubeconfig-dir.path)/kubeconfig"
-                - name: BW_CLIENTID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hypershift-bitwarden
-                      key: "BW_CLIENTID"
-                - name: BW_CLIENTSECRET
-                  valueFrom:
-                    secretKeyRef:
-                      name: hypershift-bitwarden
-                      key: "BW_CLIENTSECRET"
-                - name: BW_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: hypershift-bitwarden
-                      key: "BW_PASSWORD"
-              command:
-                - $(workspaces.source.path)/ci/images/ci-runner/hack/bin/destroy-clusters.sh
       - name: deploy-cluster
         runAfter:
           - "produce-cluster-name"
@@ -104,7 +75,7 @@ spec:
           - name: kubeconfig-dir
             workspace: kubeconfig-dir
           - name: output
-            workspace: shared-workspace
+            workspace: upgrade-shared-workspace
           - name: source
             workspace: source
         taskSpec:
@@ -154,18 +125,6 @@ spec:
                       key: "BW_PASSWORD"
               command:
                 - $(workspaces.source.path)/ci/images/ci-runner/hack/bin/deploy-cluster.sh
-      - name: fetch-repository
-        taskRef:
-          name: git-clone
-          kind: ClusterTask
-        workspaces:
-          - name: output
-            workspace: source
-        params:
-          - name: url
-            value: $(params.repo_url)
-          - name: revision
-            value: $(params.revision)
       - name: setup-ci-runner-container
         runAfter:
           - "deploy-cluster"
@@ -176,7 +135,7 @@ spec:
           - name: source
             workspace: source
           - name: kubeconfig-dir
-            workspace: shared-workspace
+            workspace: upgrade-shared-workspace
         taskSpec:
           params:
             - name: target_branch
@@ -213,7 +172,7 @@ spec:
           - "setup-ci-runner-container"
         workspaces:
           - name: kubeconfig-dir
-            workspace: shared-workspace
+            workspace: upgrade-shared-workspace
           - name: source
             workspace: source
         params:
@@ -246,10 +205,10 @@ spec:
                 - name: REPO_URL
                   value: $(params.repo_url)
                 - name: REPO_REVISION
-                  value: $(params.revision)
+                  value: $(params.target_branch)
               command:
                 - $(workspaces.source.path)/ci/images/ci-runner/hack/bin/run-plnsvc-setup.sh
-      - name: tests
+      - name: tests-before-upgrade
         runAfter:
           - "plnsvc-setup"
         params:
@@ -257,7 +216,105 @@ spec:
             value: $(params.target_branch)
         workspaces:
           - name: kubeconfig-dir
-            workspace: shared-workspace
+            workspace: upgrade-shared-workspace
+          - name: source
+            workspace: source
+        taskSpec:
+          params:
+            - name: target_branch
+          workspaces:
+            - name: kubeconfig-dir
+            - name: source
+          kind: ClusterTask
+          steps:
+            - name: run-tests
+              image: quay.io/redhat-pipeline-service/ci-runner:$(params.target_branch)
+              resources:
+                requests:
+                  memory: 500Mi
+                  cpu: 300m
+              workingDir: "$(workspaces.source.path)"
+              env:
+                - name: KUBECONFIG
+                  value: "$(workspaces.kubeconfig-dir.path)/kubeconfig"
+              command:
+                - $(workspaces.source.path)/ci/images/ci-runner/hack/bin/run-tests.sh
+      - name: fetch-repository-post-setup
+        runAfter:
+          - "tests-before-upgrade"
+        taskRef:
+          name: git-clone
+          kind: ClusterTask
+        workspaces:
+          - name: output
+            workspace: source
+        params:
+          - name: url
+            value: $(params.repo_url)
+          - name: revision
+            value: $(params.revision)
+      - name: plnsvc-upgrade
+        runAfter:
+          - "fetch-repository-post-setup"
+        workspaces:
+          - name: kubeconfig-dir
+            workspace: upgrade-shared-workspace
+          - name: source
+            workspace: source
+        params:
+          - name: repo_url
+            value: $(params.repo_url)
+          - name: revision
+            value: $(params.revision)
+          - name: target_branch
+            value: $(params.target_branch)
+        taskSpec:
+          workspaces:
+            - name: kubeconfig-dir
+            - name: source
+          params:
+            - name: repo_url
+            - name: revision
+            - name: target_branch
+          kind: ClusterTask
+          steps:
+            - name: copy-plnsvc-code
+              image: quay.io/redhat-pipeline-service/ci-runner:$(params.target_branch)
+              resources:
+                requests:
+                  memory: 500Mi
+                  cpu: 300m
+              workingDir: "$(workspaces.source.path)"
+              env:
+                - name: KUBECONFIG
+                  value: "$(workspaces.kubeconfig-dir.path)/kubeconfig"
+              command:
+                - $(workspaces.source.path)/ci/images/ci-runner/hack/bin/copy-plnsvc-code.sh
+            - name: run-plnsvc-setup
+              image: quay.io/redhat-pipeline-service/ci-runner:$(params.target_branch)
+              resources:
+                requests:
+                  memory: 500Mi
+                  cpu: 300m
+              workingDir: "$(workspaces.source.path)"
+              env:
+                - name: KUBECONFIG
+                  value: "$(workspaces.kubeconfig-dir.path)/kubeconfig"
+                - name: REPO_URL
+                  value: $(params.repo_url)
+                - name: REPO_REVISION
+                  value: $(params.revision)
+              command:
+                - $(workspaces.source.path)/ci/images/ci-runner/hack/bin/run-plnsvc-setup.sh
+      - name: tests-post-upgrade
+        runAfter:
+          - "plnsvc-upgrade"
+        params:
+          - name: target_branch
+            value: $(params.target_branch)
+        workspaces:
+          - name: kubeconfig-dir
+            workspace: upgrade-shared-workspace
           - name: source
             workspace: source
         taskSpec:
@@ -341,7 +398,7 @@ spec:
           resources:
             requests:
               storage: 3Gi
-    - name: shared-workspace
+    - name: upgrade-shared-workspace
       volumeClaimTemplate:
         spec:
           accessModes:

--- a/ci/images/ci-runner/hack/bin/deploy-cluster.sh
+++ b/ci/images/ci-runner/hack/bin/deploy-cluster.sh
@@ -21,7 +21,7 @@ fetch_bitwarden_secrets() {
 
 deploy_cluster() {
     setx_off
-    hypershift create cluster aws --pull-secret "$PULL_SECRET" --aws-creds "$AWS_CREDENTIALS"  --name "$CLUSTER_NAME"  --node-pool-replicas=2  --base-domain "$BASE_DOMAIN"  --region="$REGION" --release-image="$IMAGE" --root-volume-type=gp3 --root-volume-size=60 --instance-type=m5.xlarge
+    hypershift create cluster aws --pull-secret "$PULL_SECRET" --aws-creds "$AWS_CREDENTIALS"  --name "$CLUSTER_NAME"  --node-pool-replicas=2  --base-domain "$BASE_DOMAIN"  --region="$REGION" --release-image="$IMAGE" --root-volume-type=gp3 --root-volume-size=60 --instance-type=m5.2xlarge
     setx_on
 
     echo "Wait until hypershift hosted cluster is ready..."

--- a/operator/test/test.sh
+++ b/operator/test/test.sh
@@ -231,6 +231,7 @@ test_results() {
 
   echo
   # test both "records" and "logs" endpoints 
+  sleep 10
   fetch_results_using_rest "records"
   fetch_results_using_rest "logs"
   echo


### PR DESCRIPTION
This CI is used for testing  the upgrade upgrade. It first deploy pipeine-service on a branch new cluster .After that it applies the changes of the PR to deploy it on the same cluster.


Signed-off-by: Xin Jiang @xinredhat 