### PR TITLE
Add mechanism to freeze a dependency version

### DIFF
--- a/developer/images/dependencies-update/hack/bin/tasks/update_binaries.sh
+++ b/developer/images/dependencies-update/hack/bin/tasks/update_binaries.sh
@@ -29,7 +29,7 @@ run_task() {
     DEPENDENCIES="$WORKSPACE_DIR/shared/config/dependencies.sh"
     echo "Update binaries" >"$COMMIT_MSG"
     mapfile -t BINARIES < <(
-        grep --extended-regexp "[A-Z]*_VERSION=" "$DEPENDENCIES" \
+        grep --extended-regexp "^ *[^#]* *[A-Z]*_VERSION=" "$DEPENDENCIES" \
             | sed "s:export *\(.*\)_VERSION=.*:\1:" \
             | tr "[:upper:]" "[:lower:]" \
             | sort
@@ -45,7 +45,12 @@ run_task() {
 }
 
 update_binary() {
+    if grep --ignore-case --quiet " ${BINARY}_VERSION=.*# *Freeze" "$DEPENDENCIES"; then
+        # Ignore frozen dependencies
+        return
+    fi
     echo "$BINARY"
+    unset VERSION
     "get_${BINARY}_version"
     BINARY=$(echo "$BINARY" | tr "[:lower:]" "[:upper:]")
     sed -i -e "s:\( ${BINARY}_VERSION\)=.*:\1=\"$VERSION\":" "$DEPENDENCIES"
@@ -77,12 +82,8 @@ get_hadolint_version() {
 }
 
 get_hypershift_version() {
-    # shellcheck source=shared/config/dependencies.sh
-    source "$DEPENDENCIES"
-    if [ "$HYPERSHIFT_VERSION" != "main" ]; then
-        echo "Not implemented"
-        exit 1
-    fi
+    echo "[ERROR] Not implemented: get_hypershift_version"
+    exit 1
 }
 
 get_jq_version() {

--- a/shared/config/dependencies.sh
+++ b/shared/config/dependencies.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
+# To prevent a version to be upgraded by 'update_binaries.sh',
+# add '# Freeze' after the export.
+# E.g.:
+#       export FOOBAR_VERSION="1.2.3"  # Freeze
 export ARGOCD_VERSION="v2.5.7"
 export BITWARDEN_VERSION="v2023.1.0"
 export CHECKOV_VERSION="2.2.281"
 export GO_VERSION="1.19.5"
 export HADOLINT_VERSION="v2.12.0"
-export HYPERSHIFT_VERSION="main"
+export HYPERSHIFT_VERSION="main"  # Freeze
 export JQ_VERSION="1.6"
 export KIND_VERSION="v0.17.0"
 export KUBECTL_VERSION="v1.26.1"


### PR DESCRIPTION
The change also fixes a bug that was forcing the HyperShift version to be set with the hadolint version.