### PR TITLE
Add a feature flag to set embedded status to minimal

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -15,6 +15,7 @@ spec:
   pipeline:
     default-service-account: pipeline
     enable-tekton-oci-bundles: true
+    embedded-status: minimal
   pruner:
     keep: 10
     resources:


### PR DESCRIPTION
- Setting the embedded-status to _minimal_ can significantly reduce the size of the PipelineRun's status object. This is important for large scale production environments where large number of PipelineRuns are expected to be generated.
- The default value set for this flag is _full_. This PR updates the tektonconfig to set the value to _minimal_.