### PR TITLE
Change the name of CRB for exporter

### DIFF
--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrolebinding.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-pipeline-service-exporter-reader
+  name: pipeline-service-exporter-reader-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
- The existing name seems to be conflicting with another name in the Stonesoup cluster. Hence, I am updating the 
ClusterRoleBinding name.
- This PR will be followed by a corresponding one on infra-deployments to make the same change.