### PR TITLE
Upgrade to openshift-pipelines 1.9

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/openshift-operator.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/openshift-operator.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-pipelines-operator
   namespace: openshift-operators
 spec:
-  channel: pipelines-1.8
+  channel: pipelines-1.9
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -8,8 +8,6 @@ metadata:
     # the CRD will be applied and the resource can be created once the required dependencies are met.
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  addon:
-    enablePipelinesAsCode: false
   pipeline:
     default-service-account: pipeline
     enable-tekton-oci-bundles: true

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -8,6 +8,10 @@ metadata:
     # the CRD will be applied and the resource can be created once the required dependencies are met.
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
+  platforms:
+    openshift:
+      pipelinesAsCode:
+        enable: false
   pipeline:
     default-service-account: pipeline
     enable-tekton-oci-bundles: true


### PR DESCRIPTION
There's an urgent need to bring 1.9 to production to unblock various teams. This PR should unblock them.