### PR TITLE
Remove argocd sync-wave param from minio

### DIFF
--- a/developer/openshift/gitops/argocd/pipeline-service-storage/minio/operator/allow-argocd-to-manage.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-storage/minio/operator/allow-argocd-to-manage.yaml
@@ -3,8 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: openshift-minio-apply-tenants
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
 rules:
   - apiGroups:
       - minio.min.io
@@ -34,8 +32,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: openshift-minio-apply-tenants
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/developer/openshift/gitops/argocd/pipeline-service-storage/minio/operator/minio.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-storage/minio/operator/minio.yaml
@@ -4,8 +4,6 @@ kind: Subscription
 metadata:
   name: minio-operator
   namespace: openshift-operators
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
 spec:
   channel: stable
   installPlanApproval: Automatic

--- a/developer/openshift/gitops/argocd/pipeline-service-storage/minio/tenant/tenant.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-storage/minio/tenant/tenant.yaml
@@ -10,7 +10,6 @@ metadata:
     prometheus.io/path: /minio/v2/metrics/cluster
     prometheus.io/port: "9000"
     prometheus.io/scrape: "true"
-    argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   exposeServices:


### PR DESCRIPTION
When pipeline-service is imported in infra-deployments project (as kustomize overlays and not argcd app), the sync-wave params on minio makes introduces a kind of dead lock. That is tekton-results waiting for its storage backend and minio waiting for the first sync-wave to finish. This has been fixed by removing the sync-wave which should still let minio deploy correctly