### PR TITLE
re-enable results test for logs

### DIFF
--- a/operator/test/test.sh
+++ b/operator/test/test.sh
@@ -233,8 +233,7 @@ test_results() {
   # test both "records" and "logs" endpoints 
   sleep 10
   fetch_results_using_rest "records"
-  # disable logs test until S3 streaming is fixed
-  # fetch_results_using_rest "logs"
+  fetch_results_using_rest "logs"
   echo
 }
 


### PR DESCRIPTION
S3 streaming was fixed in 6056f750e so corresponding test can be re-enabled