### PR TITLE
downgrade pac to 0.16

### DIFF
--- a/operator/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
@@ -6,7 +6,7 @@ commonLabels:
 
 resources:
   - allow-argocd.yaml
-  - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.17.0/release.yaml
+  - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.16.0/release.yaml
 
 patchesStrategicMerge:
   - disable-pipelines-as-code-webhook.yaml


### PR DESCRIPTION
- Locally tested ✔️     
- It should also unblock @bnallapeta's PR - https://github.com/redhat-appstudio/infra-deployments/pull/1436 
### The reason for this change being PACv0.17 generates v1 PipelineRun on the cluster but 1.9 doesn't have v1 APIs.