### PR TITLE
Update tekton-results

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tekton-results
 resources:
-  - https://github.com/openshift-pipelines/tektoncd-results//config/?ref=c0e11ce68cacae1da6756713d0cb5f8b5a394b04
+  - https://github.com/openshift-pipelines/tektoncd-results.git/config/overlays/default-local-db/?ref=7dcfa61702b9e978dcdafab4d63521f6e5193ce0
   - namespace.yaml
   - api-route.yaml
   - watcher-logging-rbac.yaml
@@ -11,10 +11,10 @@ resources:
 images:
   - name: ko://github.com/tektoncd/results/cmd/api
     newName: quay.io/redhat-appstudio/tekton-results-api
-    newTag: c0e11ce68cacae1da6756713d0cb5f8b5a394b04
+    newTag: 7dcfa61702b9e978dcdafab4d63521f6e5193ce0
   - name: ko://github.com/tektoncd/results/cmd/watcher
     newName: quay.io/redhat-appstudio/tekton-results-watcher
-    newTag: c0e11ce68cacae1da6756713d0cb5f8b5a394b04
+    newTag: 7dcfa61702b9e978dcdafab4d63521f6e5193ce0
 
 # generate a new configmap with updated values (logs api, db ssl mode) and replace the default one
 configMapGenerator:


### PR DESCRIPTION
Key functional changes:

- Restore gRPC Logging: https://github.com/openshift-pipelines/tektoncd-results/commit/d2083570fa8f95dcbc34204bf65cf9a6c953d258
- Fix log streaming error due to insufficient RBAC: https://github.com/openshift-pipelines/tektoncd-results/commit/d96a9b45f6817872d543f312dbc37ac478d2bbca

Updating manually since the automation job failed and I need to test with the updated version
