### PR TITLE
fixed issue of stonesoup e2e

### DIFF
--- a/ci/images/ci-runner/hack/bin/utils.sh
+++ b/ci/images/ci-runner/hack/bin/utils.sh
@@ -150,3 +150,11 @@ get_github_accounts() {
     export GITHUB_ACCOUNTS_ARRAY
     setx_on
 }
+
+get_default_quay_org_token() {
+    get_password "8376d3eb-9b89-4420-b49d-afd9009db07b"
+    setx_off
+    DEFAULT_QUAY_ORG_TOKEN="${password}"
+    export DEFAULT_QUAY_ORG_TOKEN
+    setx_on
+}

--- a/ci/images/e2e-test-runner/run-e2e-test.sh
+++ b/ci/images/e2e-test-runner/run-e2e-test.sh
@@ -17,61 +17,77 @@ PROJECT_DIR="$(
 # shellcheck source=ci/images/ci-runner/hack/bin/utils.sh
 source "$PROJECT_DIR/ci/images/ci-runner/hack/bin/utils.sh"
 
-export GITHUB_USER GITHUB_TOKEN QUAY_TOKEN QUAY_OAUTH_USER QUAY_OAUTH_TOKEN QUAY_OAUTH_TOKEN_RELEASE_SOURCE QUAY_OAUTH_TOKEN_RELEASE_DESTINATION \
-       GITHUB_ACCOUNTS_ARRAY PREVIOUS_RATE_REMAINING GITHUB_USERNAME_ARRAY GH_RATE_REMAINING
+export_variables() {
+  printf "Export variables\n" | indent 2
+  # The following variables are exported by the Stonesoup CI:
+  # DEFAULT_QUAY_ORG DEFAULT_QUAY_ORG_TOKEN GITHUB_USER GITHUB_TOKEN QUAY_TOKEN QUAY_OAUTH_USER QUAY_OAUTH_TOKEN QUAY_OAUTH_TOKEN_RELEASE_SOURCE QUAY_OAUTH_TOKEN_RELEASE_DESTINATION 
+  # GITHUB_ACCOUNTS_ARRAY PREVIOUS_RATE_REMAINING GITHUB_USERNAME_ARRAY GH_RATE_REMAINING
 
-printf "Fetch secrets from bitwarden server\n" | indent 2
-open_bitwarden_session
-get_github_user
-get_github_token
-get_quay_token
-get_quay_oauth_user
-get_quay_oauth_token
-get_quay_oauth_token_release_source
-get_quay_oauth_token_release_destination
-get_github_accounts
+  export DEFAULT_QUAY_ORG=redhat-appstudio-qe
+  printf "Fetch secrets from bitwarden server\n" | indent 2
+
+  open_bitwarden_session
+  get_default_quay_org_token
+  get_github_user
+  get_github_token
+  get_quay_token
+  get_quay_oauth_user
+  get_quay_oauth_token
+  get_quay_oauth_token_release_source
+  get_quay_oauth_token_release_destination
+  get_github_accounts
+}
+
+handle_ratelimit() {
+  PREVIOUS_RATE_REMAINING=0
+
+  # user stored: username:token,username:token
+  for account in "${GITHUB_ACCOUNTS_ARRAY[@]}"
+  do :
+      IFS=':' read -r -a GITHUB_USERNAME_ARRAY <<< "$account"
+
+      GH_RATE_REMAINING=$(curl -s \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer ${GITHUB_USERNAME_ARRAY[1]}"\
+      https://api.github.com/rate_limit | jq ".rate.remaining")
+
+      echo -e "[INFO ] user: ${GITHUB_USERNAME_ARRAY[0]} with rate limit remaining $GH_RATE_REMAINING"
+      if [[ "${GH_RATE_REMAINING}" -ge "${PREVIOUS_RATE_REMAINING}" ]];then
+          GITHUB_USER="${GITHUB_USERNAME_ARRAY[0]}"
+          GITHUB_TOKEN="${GITHUB_USERNAME_ARRAY[1]}"
+      fi
+      PREVIOUS_RATE_REMAINING="${GH_RATE_REMAINING}"
+  done
+
+  echo -e "[INFO] Start tests with user: ${GITHUB_USER}"
+}
+
+run_test() {
+  ##git config
+  git config --global user.name "redhat-appstudio-qe-bot"
+  git config --global user.email redhat-appstudio-qe-bot@redhat.com
+
+  mkdir -p "${HOME}/creds"
+  GIT_CREDS_PATH="${HOME}/creds/file"
+  git config --global credential.helper "store --file ${GIT_CREDS_PATH}"
+  echo "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com" > "${GIT_CREDS_PATH}"
 
 
-PREVIOUS_RATE_REMAINING=0
+  cd "$(mktemp -d)"
 
-# user stored: username:token,username:token
-for account in "${GITHUB_ACCOUNTS_ARRAY[@]}"
-do :
-    IFS=':' read -r -a GITHUB_USERNAME_ARRAY <<< "$account"
+  git clone --branch main "https://${GITHUB_TOKEN}@github.com/redhat-appstudio/e2e-tests.git" .
+  ## Deploy StoneSoup
+  make local/cluster/prepare
 
-    GH_RATE_REMAINING=$(curl -s \
-    -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer ${GITHUB_USERNAME_ARRAY[1]}"\
-    https://api.github.com/rate_limit | jq ".rate.remaining")
-
-    echo -e "[INFO ] user: ${GITHUB_USERNAME_ARRAY[0]} with rate limit remaining $GH_RATE_REMAINING"
-    if [[ "${GH_RATE_REMAINING}" -ge "${PREVIOUS_RATE_REMAINING}" ]];then
-        GITHUB_USER="${GITHUB_USERNAME_ARRAY[0]}"
-        GITHUB_TOKEN="${GITHUB_USERNAME_ARRAY[1]}"
-    fi
-    PREVIOUS_RATE_REMAINING="${GH_RATE_REMAINING}"
-done
-
-echo -e "[INFO] Start tests with user: ${GITHUB_USER}"
-
-##git config
-git config --global user.name "redhat-appstudio-qe-bot"
-git config --global user.email redhat-appstudio-qe-bot@redhat.com
-
-mkdir -p "${HOME}/creds"
-GIT_CREDS_PATH="${HOME}/creds/file"
-git config --global credential.helper "store --file ${GIT_CREDS_PATH}"
-echo "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com" > "${GIT_CREDS_PATH}"
+  # Launch partial StoneSoup e2e tests
+  go mod tidy
+  go mod vendor
+  make build
+  ./bin/e2e-appstudio --ginkgo.label-filter "pipeline" --ginkgo.vv
+}
 
 
-cd "$(mktemp -d)"
 
-git clone --branch main "https://${GITHUB_TOKEN}@github.com/redhat-appstudio/e2e-tests.git" .
-## Deploy StoneSoup
-make local/cluster/prepare
-
-## Launch partial StoneSoup e2e tests
-go mod tidy
-go mod vendor
-make build
-./bin/e2e-appstudio --ginkgo.label-filter "pipeline" --ginkgo.vv
+export_variables
+handle_ratelimit
+run_test


### PR DESCRIPTION
Because [PR](https://github.com/redhat-appstudio/e2e-tests/pull/397) introduces [2 new environment variables](https://github.com/redhat-appstudio/e2e-tests/pull/397/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) that are required for bootstrapping a cluster via e2e-tests repo. We need to add the 2 new environment variables accordingly in [stonesoup-e2e-test](https://github.com/openshift-pipelines/pipeline-service/blob/main/.tekton/stonesoup-e2e-test.yaml) CI