### PR TITLE
PLNSRVCE-1268: change to allow cluster alive for 2 hours when CI task fail

### DIFF
--- a/.tekton/pipeline/acceptance-tests.yaml
+++ b/.tekton/pipeline/acceptance-tests.yaml
@@ -115,6 +115,12 @@ spec:
         - input: "$(tasks.deploy-cluster.status)"
           operator: notin
           values: ["None"]
+        - input: "$(tasks.plnsvc-setup.status)"
+          operator: notin
+          values: ["Failed"]
+        - input: "$(tasks.pipeline-service-tests.status)"
+          operator: notin
+          values: ["Failed"]
       params:
         - name: cluster-name
           value: "$(tasks.generate-cluster-name.results.cluster-name)"

--- a/.tekton/pipeline/upgrade-tests.yaml
+++ b/.tekton/pipeline/upgrade-tests.yaml
@@ -188,6 +188,24 @@ spec:
         - input: "$(tasks.deploy-cluster.status)"
           operator: notin
           values: ["None"]
+        - input: "$(tasks.plnsvc-setup.status)"
+          operator: notin
+          values: ["Failed"]
+        - input: "$(tasks.tests-before-upgrade.status)"
+          operator: notin
+          values: ["Failed"]
+        - input: "$(tasks.plnsvc-upgrade-setup.status)"
+          operator: notin
+          values: ["Failed"]
+        - input: "$(tasks.tests-post-upgrade.status)"
+          operator: notin
+          values: ["Failed"]
+        - input: "$(tasks.plnsvc-downgrade-setup.status)"
+          operator: notin
+          values: ["Failed"]
+        - input: "$(tasks.tests-post-downgrade.status)"
+          operator: notin
+          values: ["Failed"]
       params:
         - name: cluster-name
           value: "$(tasks.generate-cluster-name.results.cluster-name)"

--- a/ci/images/ci-runner/hack/bin/destroy-clusters.sh
+++ b/ci/images/ci-runner/hack/bin/destroy-clusters.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(
 # shellcheck source=ci/images/ci-runner/hack/bin/utils.sh
 source "$SCRIPT_DIR/utils.sh"
 
-MAX_DURATION_MINS=60
+MAX_DURATION_MINS=120
 EXCLUDE_CLUSTER=(local-cluster)
 
 delete_cluster() {


### PR DESCRIPTION
**Changes:**
1. When one of CI tasks fail, such as `plnsvc-setup` , CI won't destroy the cluster
2. The cluster will be kept alive for around 2 hours, when it exceeds  2 hours, it probably will be destroyed automatically 