### PR TITLE
Update metrics-exporter kustomization to use images built from RHTAP

### DIFF
--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: pipeline-service-exporter
       containers:
         - name: pipeline-metrics-exporter
-          image: quay.io/redhat-pipeline-service/metrics-exporter:45db641
+          image: quay.io/redhat-appstudio/user-workload:main
           ports:
             - containerPort: 9117
           resources:

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml
@@ -6,5 +6,10 @@ resources:
   - deployment.yaml
   - service.yaml
 
+images:
+  - name: quay.io/redhat-appstudio/user-workload
+    newName: quay.io/redhat-appstudio/user-workload
+    newTag: 9ff3255f3ca2b4a562be2d5f43f8dff2f7846bb1
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
- Provides an option to set image name and tag in the kustomization.yaml
- Sets default tag to main in the deployment.yaml as a placeholder. When pipeline service is deployed, kustomization would override with the tag in the file.
- Update metrics-exporter kustomization to use images built from RHTAP