### PR TITLE
Extended wait time for deployments/tekton-results-api to be ready

### DIFF
--- a/operator/images/cluster-setup/content/bin/utils.sh
+++ b/operator/images/cluster-setup/content/bin/utils.sh
@@ -39,7 +39,7 @@ check_deployments() {
     fi
 
     #a loop to check if the deployment is Available and Ready
-    if kubectl wait --for=condition=Available=true "deployment/$deploy" -n "$ns" --timeout=100s >/dev/null; then
+    if kubectl wait --for=condition=Available=true "deployment/$deploy" -n "$ns" --timeout=200s >/dev/null; then
       printf ", Ready\n"
     else
       kubectl -n "$ns" describe "deployment/$deploy"


### PR DESCRIPTION
This is to fix the issue of [PLNSRVCE-1267](https://issues.redhat.com/browse/PLNSRVCE-1267) , the root cause is that Deployment tekton-results-api needs more time to be ready