### PR TITLE
Use HSTS header for tekton-results api route.

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/api-route.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/api-route.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-results
   annotations:
     openshift.io/host.generated: "true"
+    haproxy.router.openshift.io/hsts_header: "max-age=63072000"
 spec:
   to:
     kind: Service


### PR DESCRIPTION
Use HSTS header for tekton-results api route. This option should include HSTS (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header to response.

![screenshot-nimbusweb me-2023 04 06-19_41_36](https://user-images.githubusercontent.com/6873095/230444653-824ae8c2-a090-4a5b-a628-227514add53f.png)
