### PR TITLE
PLNSRVCE-1152: update checkov static checks; turn off checkov soft fail; add openshift scc/hostnetwork tests

### DIFF
--- a/.tekton/pipeline-service-static-code-analysis.yaml
+++ b/.tekton/pipeline-service-static-code-analysis.yaml
@@ -118,7 +118,7 @@ spec:
               image: quay.io/redhat-pipeline-service/static-checks:$(params.target_branch)
               script: |
                 #!/usr/bin/env bash
-                /opt/static-checks/bin/checkov.sh --workspace_dir $(workspaces.source.path)
+                $(workspaces.source.path)/ci/images/static-checks/content/bin/checkov.sh --workspace_dir $(workspaces.source.path) --config-file $(workspaces.source.path)/ci/images/static-checks/content/config/checkov.yaml
           workspaces:
             - name: source
   workspaces:

--- a/ci/images/static-checks/content/bin/checkov.sh
+++ b/ci/images/static-checks/content/bin/checkov.sh
@@ -33,12 +33,15 @@ usage() {
 Usage:
     ${0##*/} [options]
 
-Run yamllint in the content of the workspace directory
+Run checkov against the content of the workspace directory
 
 Optional arguments:
     -w, --workspace_dir WORKSPACE_DIR.
         Workspace directory.
         Default: $PROJECT_DIR
+    -c, --config-file CONFIG_FILE
+        Configuration file.
+        Default: the path '../config/checkov.yaml' from this script
     -d, --debug
         Activate tracing/debug mode.
     -h, --help
@@ -51,6 +54,7 @@ Example:
 
 parse_args() {
     WORKSPACE_DIR="$PROJECT_DIR"
+    CONFIG_FILE="$SCRIPT_DIR/../config/checkov.yaml"
     while [[ $# -gt 0 ]]; do
         case $1 in
         -w | --workspace_dir)
@@ -65,6 +69,10 @@ parse_args() {
         -h | --help)
             usage
             exit 0
+            ;;
+        -c | --config-file)
+            shift
+            CONFIG_FILE="$1"
             ;;
         *)
             echo "[ERROR] Unknown argument: $1" >&2
@@ -81,7 +89,7 @@ init() {
 }
 
 run() {
-    checkov --directory "$WORKSPACE_DIR" --config-file "$SCRIPT_DIR/../config/checkov.yaml"
+    checkov --directory "$WORKSPACE_DIR" --config-file "$CONFIG_FILE"
 }
 
 main() {

--- a/ci/images/static-checks/content/config/checkov.yaml
+++ b/ci/images/static-checks/content/config/checkov.yaml
@@ -13,7 +13,47 @@ quiet: true
 skip-check:
   # skip Healthcheck instruction error for Docker Images
   - CKV_DOCKER_2
+  # not enforcing liveness/readiness probes at this time; minimally, chains, results, metric exporter do not have
+  # we have opened https://github.com/tektoncd/results/issues/280 upstream
+  - CKV_K8S_8
+  - CKV_K8S_9
+  # RHTAP utilizes LimitRanges for cpu/mem requests and limits settings (handles 10-13)
+  - CKV_K8S_10
+  - CKV_K8S_11
+  - CKV_K8S_12
+  - CKV_K8S_13
+  # image ref related
+  - CKV_K8S_43 # deployments referenced by checkov are either items like chains which will be replace by openshift-pipelines 1.10 or a fooled by our use of kustomize for image setting
+  - CKV_K8S_14 # deployments referenced by checkov are either items like chains which will be replace by openshift-pipelines 1.10 or a fooled by our use of kustomize for image setting
+  - CKV_K8S_15 # with sha specific image refs setting pull policy to always is redundant and negates us of openshift node cache
+  # need to reivew chains/pac needs to read secrets in a couple of namespaces, not a clusterrolebinding, create webhooks
+  - CKV2_K8S_5
+  # there is no use of hostPID, hostIPC, hostNetwork in repo, but scan complains about not setting explicitly to false
+  # will check in live tests
+  - CKV_K8S_17
+  - CKV_K8S_18
+  - CKV_K8S_19
+  # openshift scc / security addresses these check by mutating pod under the covers
+  # with pods getting assigned the restricted scc unless explicitly allowed otherwise
+  - CKV_K8S_20 # no allowPrivilegeEscalation
+  - CKV_K8S_22 # read only FS
+  - CKV_K8S_23 # admission of root containers
+  - CKV_K8S_25 # we are not adding capabilities, running under restricted-scc
+  - CKV_K8S_28 # admission of NET RAW capability
+  - CKV_K8S_29 # apply security context to pod and containers
+  - CKV_K8S_30 # apply security context to containers
+  - CKV_K8S_31 # runtime/default seccomp profile
+  - CKV_K8S_33 # also, no kubernetes-dashboard on openshift
+  - CKV_K8S_37 # any capabilities
+  - CKV_K8S_38 # our pods almost always a) need to access api svr, b) do not have privileged SA
+  - CKV_K8S_40 # high UID number
+  - CKV_K8S_35 # opened https://github.com/tektoncd/results/issues/432 for secrets via env var
+  # need to allow argocd to create/delete the validatingadmissionwebhooks for tekton (core part of knative)
+  - CKV_K8S_155
+  - CKV_K8S_157
+  - CKV2_K8S_6 # use NetworkPolicy like what registration-service and integration-service employ are untenable for tekton controllers
 skip-fixes: true
-soft-fail: true
+soft-fail: false
 skip-path:
   - developer
+  - ci


### PR DESCRIPTION
1) openshift pod security / security context contraints ultimately mutates pods on their creation from deployments, etc. and fools the generic k8s `checkov` scans; this PR adds skips on the scans directly mutated 

2) a few miscellaneous skips were also added based on analysis

based on how things go, and if we can get to an acceptable baseline, we can set `soft-fail` to false, and in theory have PR checks fail if upstream changes lead to security violations we are not happy with

3) added some bash to verify that all are pods are running with the restricted SCC, which effectively replaces specific checks from `checkov` that we are now skipping