### PR TITLE
WIP: Run Upgrade Test from AppStudio sha

### DIFF
--- a/.tekton/pipeline-service-upgrade-test.yaml
+++ b/.tekton/pipeline-service-upgrade-test.yaml
@@ -27,6 +27,8 @@ spec:
       value: "{{ revision }}"
     - name: target_branch
       value: "{{ target_branch }}"
+    - name: start_revision
+      value: 8f3ebf86101a4cf21fe7e86335e85a3fb6e3671f
   timeouts:
     pipeline: "1h0m0s"
   workspaces:

--- a/.tekton/pipeline/upgrade-tests.yaml
+++ b/.tekton/pipeline/upgrade-tests.yaml
@@ -6,8 +6,23 @@ metadata:
 spec:
   params:
     - name: repo_url
+      type: string
+      description: URL to git repository
     - name: revision
+      type: string
+      description: |
+        Commit SHA that Pipeline Service will upgrade to. This will either be
+        the commit for a pull request, or the commit of merged code.
     - name: target_branch
+      type: string
+      description: |
+        Target branch that initiated the pipeline - either a contributor's
+        branch for a pull request, or the branch name from a push event.
+    - name: start_revision
+      type: string
+      description: |
+        Commit SHA that Pipeline Service will upgrade from. This should be the
+        commit for a deployed version of Pipeline Service.
   timeouts:
     finally: "0h20m0s"
   workspaces:
@@ -78,7 +93,7 @@ spec:
         - name: repo_url
           value: $(params.repo_url)
         - name: revision
-          value: $(params.revision)
+          value: $(params.start_revision)
         - name: target_branch
           value: $(params.target_branch)
     - name: tests-before-upgrade

--- a/developer/openshift/dev_setup.sh
+++ b/developer/openshift/dev_setup.sh
@@ -120,6 +120,8 @@ init() {
   GIT_URL=$(yq '.git_url // "https://github.com/openshift-pipelines/pipeline-service.git"' "$CONFIG")
   GIT_REF=$(yq '.git_ref // "main"' "$CONFIG")
 
+  echo "Deploying Pipeline Service from $GIT_URL ref:$GIT_REF"
+
   # Create SRE repository folder
   WORK_DIR="${WORK_DIR:-}"
   if [[ -z "$WORK_DIR" ]]; then


### PR DESCRIPTION
Ensure that the Pipeline Service upgrade test runs a full upgrade from what is currently deployed in the AppStudio staging cluster. This should help us catch any upgrade failures/risks before they are deployed in AppStudio.

- Add `start_revision` parameter to upgrade test pipeline.
- Add fuller descriptions to upgrade test pipeline parameters.
- dev_setup.sh: Print the git URL and ref that Pipeline Service uses for its ArgoCD deployment.

This is an attempt to simulate the failure that caused [PLNSRVCE-1262](https://issues.redhat.com/browse/PLNSRVCE-1262)