### PR TITLE
allow placement-service-manager to dump pods, pods/logs

### DIFF
--- a/operator/gitops/compute/pipeline-service-manager/role.yaml
+++ b/operator/gitops/compute/pipeline-service-manager/role.yaml
@@ -7,6 +7,15 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
+      - pods/logs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - namespaces
     verbs:
       - get


### PR DESCRIPTION
Unfortunately the logs have already been pruned in CI, but during the failed run https://console-openshift-console.apps.pipeline-stage.3jhu.p1.openshiftapps.com/k8s/ns/pipeline-service-ci/tekton.dev~v1beta1~PipelineRun/pipeline-service-test-fc4kx/logs/plnsvc-setup

I got a permission error stating that the `placement-service-manager` SA could not get pod logs while running https://github.com/openshift-pipelines/pipeline-service/blob/2e84c5ef368b605ef99e4b9ba70972daeee73b39/operator/images/cluster-setup/content/bin/utils.sh#L46

