### PR TITLE
tektoncd-results update

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
@@ -15,6 +15,9 @@ images:
   - name: ko://github.com/tektoncd/results/cmd/watcher
     newName: quay.io/redhat-appstudio/tekton-results-watcher
     newTag: 4c93d5c4f34d96d31ade787ee1856d144e342143
+  - name: ko://github.com/tektoncd/results/tools/migrator
+    newName: quay.io/redhat-appstudio/tekton-results-migrator
+    newTag: 4c93d5c4f34d96d31ade787ee1856d144e342143
 
 # generate a new configmap with updated values (logs api, db ssl mode) and replace the default one
 configMapGenerator:

--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tekton-results
 resources:
-  - https://github.com/openshift-pipelines/tektoncd-results.git/config/overlays/default-local-db/?ref=7dcfa61702b9e978dcdafab4d63521f6e5193ce0
+  - https://github.com/openshift-pipelines/tektoncd-results.git/config/overlays/default-local-db/?ref=4c93d5c4f34d96d31ade787ee1856d144e342143
   - namespace.yaml
   - api-route.yaml
   - watcher-logging-rbac.yaml
@@ -11,10 +11,10 @@ resources:
 images:
   - name: ko://github.com/tektoncd/results/cmd/api
     newName: quay.io/redhat-appstudio/tekton-results-api
-    newTag: 7dcfa61702b9e978dcdafab4d63521f6e5193ce0
+    newTag: 4c93d5c4f34d96d31ade787ee1856d144e342143
   - name: ko://github.com/tektoncd/results/cmd/watcher
     newName: quay.io/redhat-appstudio/tekton-results-watcher
-    newTag: 7dcfa61702b9e978dcdafab4d63521f6e5193ce0
+    newTag: 4c93d5c4f34d96d31ade787ee1856d144e342143
 
 # generate a new configmap with updated values (logs api, db ssl mode) and replace the default one
 configMapGenerator:

--- a/operator/images/cluster-setup/content/bin/utils.sh
+++ b/operator/images/cluster-setup/content/bin/utils.sh
@@ -103,7 +103,7 @@ check_deployments() {
       printf ", Ready\n"
     else
       kubectl -n "$ns" describe "deployment/$deploy"
-      kubectl -n "$ns" logs "deployment/$deploy"
+      kubectl -n "$ns" logs "deployment/$deploy --all-containers"
       kubectl -n "$ns" get events | grep Warning
       exit 1
     fi


### PR DESCRIPTION
replaces https://github.com/openshift-pipelines/pipeline-service/pull/590 since we had to add the migrator image to the replace images section

@sayan-biswas @adambkaplan @Roming22 FYI
