### PR TITLE
Allow pipeline-service-manager to view subscriptions

### DIFF
--- a/operator/gitops/compute/pipeline-service-manager/role.yaml
+++ b/operator/gitops/compute/pipeline-service-manager/role.yaml
@@ -117,3 +117,11 @@ rules:
       - patch
       - delete
       - deletecollection
+  - apiGroups:
+      - "operators.coreos.com"
+    resources:
+      - subscriptions
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
This permission is required when installing the cluster with dev_setup.sh