### PR TITLE
Migrator config patches

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/api-migrator-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/api-migrator-config.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-api
+  namespace: tekton-pipelines
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: migrator
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tekton-results-database
+                  key: db.user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: tekton-results-database
+                  key: db.password
+            - name: DB_HOST
+              value:
+              valueFrom:
+                secretKeyRef:
+                  name: tekton-results-database
+                  key: db.host
+            - name: DB_NAME
+              value:
+              valueFrom:
+                secretKeyRef:
+                  name: tekton-results-database
+                  key: db.name

--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
@@ -15,6 +15,9 @@ images:
   - name: ko://github.com/tektoncd/results/cmd/watcher
     newName: quay.io/redhat-appstudio/tekton-results-watcher
     newTag: 4c93d5c4f34d96d31ade787ee1856d144e342143
+  - name: ko://github.com/tektoncd/results/tools/migrator
+    newName: quay.io/redhat-appstudio/tekton-results-migrator
+    newTag: 4c93d5c4f34d96d31ade787ee1856d144e342143
 
 # generate a new configmap with updated values (logs api, db ssl mode) and replace the default one
 configMapGenerator:

--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
@@ -30,6 +30,7 @@ configMapGenerator:
     behavior: replace
 
 patchesStrategicMerge:
+  - api-migrator-config.yaml
   - api-db-config.yaml
   - api-s3-config.yaml
   - api-service-tls.yaml

--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tekton-results
 resources:
-  - https://github.com/openshift-pipelines/tektoncd-results.git/config/overlays/default-local-db/?ref=7dcfa61702b9e978dcdafab4d63521f6e5193ce0
+  - https://github.com/openshift-pipelines/tektoncd-results.git/config/overlays/default-local-db/?ref=4c93d5c4f34d96d31ade787ee1856d144e342143
   - namespace.yaml
   - api-route.yaml
   - watcher-logging-rbac.yaml
@@ -11,10 +11,10 @@ resources:
 images:
   - name: ko://github.com/tektoncd/results/cmd/api
     newName: quay.io/redhat-appstudio/tekton-results-api
-    newTag: 7dcfa61702b9e978dcdafab4d63521f6e5193ce0
+    newTag: 4c93d5c4f34d96d31ade787ee1856d144e342143
   - name: ko://github.com/tektoncd/results/cmd/watcher
     newName: quay.io/redhat-appstudio/tekton-results-watcher
-    newTag: 7dcfa61702b9e978dcdafab4d63521f6e5193ce0
+    newTag: 4c93d5c4f34d96d31ade787ee1856d144e342143
 
 # generate a new configmap with updated values (logs api, db ssl mode) and replace the default one
 configMapGenerator:


### PR DESCRIPTION
Add patches to migrator database config to transform DB secret key values.

Causing error in pod creation:
container "migrator" in pod "tekton-results-api-5fd5f67554-4vkvz" is waiting to start: CreateContainerConfigError