### PR TITLE
Upgrading Openshift Pipelines Operator from 1.9 to 1.10

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/openshift-operator.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/openshift-operator.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-pipelines-operator
   namespace: openshift-operators
 spec:
-  channel: pipelines-1.9
+  channel: pipelines-1.10
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The PR brings in the below changes:
- Upgrades OpenShift Pipelines Operator to 1.10