### PR TITLE
allow for watcher logging level customization via gitops

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
@@ -35,4 +35,5 @@ patchesStrategicMerge:
   - api-s3-config.yaml
   - api-service-tls.yaml
   - watcher-config.yaml
+  - watcher-logging.yaml
   - delete-postgres.yaml

--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/watcher-logging.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/watcher-logging.yaml
@@ -1,0 +1,14 @@
+# Adjust logging level of the watcher
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-results-config-logging
+  namespace: tekton-pipelines
+data:
+  loglevel.controller: info
+  loglevel.watcher: info
+  zap-logger-config: |
+    {
+      "level": "info",
+    }


### PR DESCRIPTION
During debugging the issues bumping results to `downstream-0.5.0-02` I discovered you could not use https://github.com/openshift-pipelines/tektoncd-results/blob/downstream-0.5.0-02/config/base/env/config to bump the logging levels for the watcher pod.  Those only changed the log level in the api server.

There appear to be valid reasons why that env var based approach is not enabled for the watcher when you look at the code, and the doc explicitly steers one to use the knative based config map approach.

So to reconcile with our use of gitops, I'm exposing manipulation of the requisite fields here.

I have successfully tested this using https://github.com/openshift-pipelines/pipeline-service/blob/main/developer/config.yaml and presumably it should work then with `--use-current-branch` as well

