### PR TITLE
PLNSRVCE-1292: only create tekton-results-manifests once in CI tests (especially upgrade test)

### DIFF
--- a/operator/gitops/compute/pipeline-service-manager/role.yaml
+++ b/operator/gitops/compute/pipeline-service-manager/role.yaml
@@ -37,6 +37,7 @@ rules:
       - apps
     resources:
       - deployments
+      - statefulsets
     verbs:
       - "*"
   - apiGroups:

--- a/operator/images/access-setup/content/bin/setup_work_dir.sh
+++ b/operator/images/access-setup/content/bin/setup_work_dir.sh
@@ -172,6 +172,18 @@ tekton_chains_manifest(){
 }
 
 tekton_results_manifest(){
+  miniosecret="$(kubectl get secrets minio-storage-configuration -o name -n tekton-results --ignore-not-found)"
+  if [ -z "$miniosecret" ]; then
+    printf "Need to create tekton results manifests for DB and S3 \n"
+  else
+    printf "Tekton results secrets already in place, returning from tekton_results_manifest \n"
+    # create minimal kustomization.yaml so calling function does not need to check for the secret as well
+    mkdir -p "$manifests_dir/compute/tekton-results"
+    kubectl create namespace tekton-results --dry-run=client -o yaml > "$manifests_dir/compute/tekton-results/namespace.yaml"
+    yq e -n '.resources += ["namespace.yaml"]' > "$manifests_dir/compute/tekton-results/kustomization.yaml"
+    return
+  fi
+
   results_kustomize="$manifests_dir/compute/tekton-results/kustomization.yaml"
   results_namespace="$manifests_dir/compute/tekton-results/namespace.yaml"
   results_db_secret="$manifests_dir/compute/tekton-results/tekton-results-db-secret.yaml"

--- a/operator/images/cluster-setup/content/bin/install.sh
+++ b/operator/images/cluster-setup/content/bin/install.sh
@@ -139,6 +139,8 @@ install_clusters() {
     check_deployments "openshift-pipelines" "${tektonDeployments[@]}" | indent 4
     resultsDeployments=("tekton-results-api" "tekton-results-watcher")
     check_deployments "tekton-results" "${resultsDeployments[@]}" | indent 4
+    resultsStatefulsets=("postgres-postgresql" "storage-pool-0")
+    check_statefulsets "tekton-results" "${resultsStatefulsets[@]}" | indent 4
     chainsDeployments=("tekton-chains-controller")
     check_deployments "tekton-chains" "${chainsDeployments[@]}" | indent 4
   done


### PR DESCRIPTION
OK this addresses and issue that @scoheb first reported to us when doing an upgrade on his long running cluster, where @AndrienkoAleksandr and I did enough debug that we saw the `minio-storage-configuration` and `` secrets had mismatched S3 passwords, leading to the result api server's `mc` init container complaining about such a mismatch, followed by @adambkaplan saying he same something similar, and then finally, something @sayan-biswas and I have seen pretty consistently this show up when debug attempt to bump the version of downstream results in this repo.

Bottom line, multiple calls to the password generation in via `openssl rand ..` lead to regeneration of the password.  That coupled with gitops/kustomize concurrency, lead to intermittent to fairly consistent mismatches.

The solution:  we only need to generate those results passwords once for even our upgrade test.  i.e. the "KISS" principle.
Aside from minio being dev only, password management works differently in staging  / prod then our gitops/kustomize approach here anyway, so there is no test value.

I've separated this out from https://github.com/openshift-pipelines/pipeline-service/pull/617 or related PR because aside from the upgrade steps, the downgrade steps can also lead to this S3 password mismatch in the different secrets.

My hope is to get this merged, so we can get an entirely clean / consistent run on the results bump PR #617 

@AndrienkoAleksandr for some reason I cannot select you as a reviewer, but PTAL