### PR TITLE
[DNM] Add a dedicated service account to run Tekton pipelines

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/appstudio-pipelines-runner-clusterrole.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/appstudio-pipelines-runner-clusterrole.yaml
@@ -1,0 +1,54 @@
+---
+# Any change to this role must be communicated to the devsandbox team
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-pipelines-runner-clusterrole
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+    verbs:
+      - get
+      - list
+      - update
+      - patch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - taskruns
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - taskruns/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - sharedresource.openshift.io
+    resourceNames:
+      - redhat-appstudio-user-workload
+    resources:
+      - sharedsecrets
+    verbs:
+      - use
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - csi-scc
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - allow-argocd-to-manage.yaml
+  - appstudio-pipelines-runner-clusterrole.yaml
   - openshift-operator.yaml
   - tekton-config.yaml

--- a/operator/test/manifests/test/tekton-chains/public-key.yaml
+++ b/operator/test/manifests/test/tekton-chains/public-key.yaml
@@ -20,4 +20,4 @@ spec:
                 set -x
                 PUBLIC_KEY=$(oc get secret public-key -n tekton-chains -o jsonpath='{.data.cosign\.pub}')
                 echo "$PUBLIC_KEY" | base64 -d
-  serviceAccountName: pipeline
+  serviceAccountName: appstudio-pipeline

--- a/operator/test/manifests/test/tekton-chains/simple-copy-pipeline.yaml
+++ b/operator/test/manifests/test/tekton-chains/simple-copy-pipeline.yaml
@@ -2,7 +2,6 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  annotations:
   name: simple-copy
 spec:
   params:

--- a/operator/test/manifests/test/tekton-pipelines/appstudio-pipeline-service-account.yaml
+++ b/operator/test/manifests/test/tekton-pipelines/appstudio-pipeline-service-account.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appstudio-pipeline
+  namespace: plnsvc-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-pipelines-edit-rolebinding
+  namespace: plnsvc-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: appstudio-pipeline
+    namespace: plnsvc-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-pipelines-scc-rolebinding
+  namespace: plnsvc-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pipelines-scc-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: appstudio-pipeline
+    namespace: plnsvc-tests

--- a/operator/test/manifests/test/tekton-pipelines/kustomization.yaml
+++ b/operator/test/manifests/test/tekton-pipelines/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - appstudio-pipeline-service-account.yaml

--- a/operator/test/test.sh
+++ b/operator/test/test.sh
@@ -83,11 +83,7 @@ setup_test() {
     echo -n "."
     kubectl create namespace "$NAMESPACE" >/dev/null
   fi
-  # Wait for pipelines to set up all the components
-  while [ "$(kubectl get serviceaccounts -n "$NAMESPACE" | grep -cE "^pipeline ")" != "1" ]; do
-    echo -n "."
-    sleep 2
-  done
+  kubectl apply -k "$SCRIPT_DIR/manifests/test/tekton-pipelines" -n "$NAMESPACE" >/dev/null
   echo "OK"
   echo
 }
@@ -154,6 +150,7 @@ test_chains() {
     tkn -n "$NAMESPACE" pipeline start simple-copy \
       --param image-src="$image_src" \
       --param image-dst="$image_dst" \
+      --serviceaccount="appstudio-pipeline" \
       --workspace name=shared,pvc,claimName="tekton-build" |
       head -1 | sed "s:.* ::"
   )"


### PR DESCRIPTION
The service account is to be created automatically on tenant namespace creation. The definition of the ClusterRole is managed by pipeline service.