### PR TITLE
Downgrade PaC image to 1.9.2-1

### DIFF
--- a/operator/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
@@ -28,7 +28,7 @@ patchesJson6902:
       - op: replace
         path: "/spec/template/spec/containers/0/image"
         value:
-          registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8:v1.10.0-6
+          registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8:v1.9.2-1
   - target:
       kind: Deployment
       name: pipelines-as-code-watcher
@@ -37,7 +37,7 @@ patchesJson6902:
       - op: replace
         path: "/spec/template/spec/containers/0/image"
         value:
-          registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8:v1.10.0-6
+          registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8:v1.9.2-1
   - target:
       kind: Deployment
       name: pipelines-as-code-webhook
@@ -46,4 +46,4 @@ patchesJson6902:
       - op: replace
         path: "/spec/template/spec/containers/0/image"
         value:
-          registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8:v1.10.0-6
+          registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8:v1.9.2-1


### PR DESCRIPTION
Workaround for SRVKP-3064.
This is acceptable because we do not require the latest PaC version at the moment.