### PR TITLE
Align Pipelines Controller logs with ADR-6

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/config-logging.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/config-logging.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: openshift-pipelines
+  labels:
+    app.kubernetes.io/component: resolvers
+    app.kubernetes.io/part-of: tekton-pipelines
+    app.kubernetes.io/instance: default
+    operator.tekton.dev/operand-name: tektoncd-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+data:
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "sampling": {
+        "initial": 100,
+        "thereafter": 100
+      },
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "string",
+        "callerEncoder": ""
+      }
+    }
+  # Log level overrides
+  loglevel.controller: "info"
+  loglevel.webhook: "info"

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - allow-argocd-to-manage.yaml
   - openshift-operator.yaml
   - tekton-config.yaml
+  - config-logging.yaml


### PR DESCRIPTION
align Pipelines Controller logs with ADR-6    
         - add config-logging to patch default configmap used for setting zap encoder.