### PR TITLE
 Retain zap logging config for tekton results

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/base/watcher-logging.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/base/watcher-logging.yaml
@@ -1,4 +1,3 @@
-# Adjust logging level of the watcher
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -6,9 +5,28 @@ metadata:
   name: tekton-results-config-logging
   namespace: tekton-pipelines
 data:
-  loglevel.controller: info
-  loglevel.watcher: info
+  # Adjust zap-logger config according to ADR 6
   zap-logger-config: |
     {
       "level": "info",
+      "development": false,
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "string",
+        "callerEncoder": ""
+      }
     }
+  # Adjust logging level of the watcher and controller
+  loglevel.watcher: info
+  loglevel.controller: info


### PR DESCRIPTION
- a previous PR removed the zap-logger-config data, because in config map
  patches, data is replaced and not patched, refer #616
- add missing data to zap-logger-config
- update zap-logging-config according to ADR 6
- Refer PLNSRVCE-1308

Signed-off-by: Avinal Kumar <avinal@redhat.com>
