### PR TITLE
Change default SA for Pipelines to appstudio-pipeline

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -8,12 +8,15 @@ metadata:
     # the CRD will be applied and the resource can be created once the required dependencies are met.
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
+  # params:
+  #   - name: createRbacResource
+  #     value: "false"
   platforms:
     openshift:
       pipelinesAsCode:
         enable: false
   pipeline:
-    default-service-account: pipeline
+    default-service-account: appstudio-pipeline
     enable-bundles-resolver: true
     enable-cluster-resolver: true
     enable-git-resolver: true

--- a/operator/test/manifests/setup/pipeline-service/appstudio-pipeline-service-account.yaml
+++ b/operator/test/manifests/setup/pipeline-service/appstudio-pipeline-service-account.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appstudio-pipeline
+  namespace: plnsvc-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-pipelines-runner-clusterrole
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+    verbs:
+      - get
+      - list
+      - update
+      - patch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - taskruns
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - taskruns/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - sharedresource.openshift.io
+    resourceNames:
+      - redhat-appstudio-user-workload
+    resources:
+      - sharedsecrets
+    verbs:
+      - use
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - csi-scc
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-pipelines-runner-rolebinding
+  namespace: plnsvc-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-runner-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: appstudio-pipeline
+    namespace: plnsvc-tests

--- a/operator/test/manifests/setup/pipeline-service/kustomization.yaml
+++ b/operator/test/manifests/setup/pipeline-service/kustomization.yaml
@@ -2,5 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - chains-test-service-account.yaml
-  - simple-copy-pipeline.yaml
+  - appstudio-pipeline-service-account.yaml
+  - namespace.yaml

--- a/operator/test/manifests/setup/pipeline-service/namespace.yaml
+++ b/operator/test/manifests/setup/pipeline-service/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: plnsvc-tests

--- a/operator/test/manifests/test/tekton-chains/chains-test-service-account.yaml
+++ b/operator/test/manifests/test/tekton-chains/chains-test-service-account.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chains-test
+  namespace: plnsvc-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chains-test-edit-rolebinding
+  namespace: plnsvc-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: chains-test
+    namespace: plnsvc-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chains-test-scc-rolebinding
+  namespace: plnsvc-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pipelines-scc-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: chains-test
+    namespace: plnsvc-tests

--- a/operator/test/test.sh
+++ b/operator/test/test.sh
@@ -79,15 +79,7 @@ init() {
 setup_test() {
   echo "[Setup]"
   echo -n "  - Namespace configuration: "
-  if ! kubectl get namespace $NAMESPACE >/dev/null 2>&1; then
-    echo -n "."
-    kubectl create namespace "$NAMESPACE" >/dev/null
-  fi
-  # Wait for pipelines to set up all the components
-  while [ "$(kubectl get serviceaccounts -n "$NAMESPACE" | grep -cE "^pipeline ")" != "1" ]; do
-    echo -n "."
-    sleep 2
-  done
+  kubectl apply -k "$SCRIPT_DIR/manifests/setup/pipeline-service" >/dev/null
   echo "OK"
   echo
 }
@@ -154,6 +146,7 @@ test_chains() {
     tkn -n "$NAMESPACE" pipeline start simple-copy \
       --param image-src="$image_src" \
       --param image-dst="$image_dst" \
+      --serviceaccount "chains-test" \
       --workspace name=shared,pvc,claimName="tekton-build" |
       head -1 | sed "s:.* ::"
   )"


### PR DESCRIPTION
The pipeline service account permissions are too open by default. Therefore the account needs to be replaced with an account with more limited permissions.

The service account is managed by the DevSandbox team.