### PR TITLE
Revert "Use downstream images for pipelines-as-code and tekton-chains"

### DIFF
--- a/operator/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
@@ -20,30 +20,3 @@ patchesJson6902:
         path: "/metadata/labels"
         value:
           argocd.argoproj.io/managed-by: openshift-gitops
-  - target:
-      kind: Deployment
-      name: pipelines-as-code-controller
-      namespace: pipelines-as-code
-    patch: |-
-      - op: replace
-        path: "/spec/template/spec/containers/0/image"
-        value:
-          registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8:v1.9.2-1
-  - target:
-      kind: Deployment
-      name: pipelines-as-code-watcher
-      namespace: pipelines-as-code
-    patch: |-
-      - op: replace
-        path: "/spec/template/spec/containers/0/image"
-        value:
-          registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8:v1.9.2-1
-  - target:
-      kind: Deployment
-      name: pipelines-as-code-webhook
-      namespace: pipelines-as-code
-    patch: |-
-      - op: replace
-        path: "/spec/template/spec/containers/0/image"
-        value:
-          registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8:v1.9.2-1

--- a/operator/gitops/argocd/pipeline-service/tekton-chains/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/kustomization.yaml
@@ -39,12 +39,3 @@ patches:
         name: signing-secrets
         namespace: tekton-chains
       $patch: delete
-  # Use downstream image
-  - target:
-      kind: Deployment
-      name: tekton-chains-controller
-      namespace: tekton-chains
-    patch: |-
-     - op: replace
-       path: /spec/template/spec/containers/0/image
-       value: registry.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel8:v1.10.0-4


### PR DESCRIPTION
**This commit should only be merged by @gabemontero or @Roming22**

This reverts commit 04a0df2558ebb6879c2a413fc4f7d1ade53f5d6f.

This is a workaround in case we're still having issues with the AppStudio e2e tests at the end of the day.