### PR TITLE
[FREEZE] add pipelines-scc

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
@@ -5,3 +5,6 @@ resources:
   - allow-argocd-to-manage.yaml
   - openshift-operator.yaml
   - tekton-config.yaml
+  # Once we disable RBAC creation in Tekton-config, SCC will not be created automatically
+  # by Openshift-Pipelines operator
+  - pipelines-scc.yaml

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/pipelines-scc.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/pipelines-scc.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: pipelines-scc
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+  - SETFCAP
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+  - system:cluster-admins
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret


### PR DESCRIPTION
Once we disable RBAC creation in Tekton-config, SCC will not be created automatically by Openshift-Pipelines operator.
Not sure how quickly we want this PR merged, since we're good for now. 