### PR TITLE
Fix possible race issue

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-config.yaml
@@ -168,6 +168,7 @@ metadata:
   name: tekton-chains-trusted-cabundle
   namespace: tekton-chains
   annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   template:
     spec:


### PR DESCRIPTION
It was possible for the tekton-chains-trusted-cabundle job to run before the config-trusted-cabundle was cleaned by the OSP operator