### PR TITLE
PLNSRVCE-1284 : check pods for control plane namespace

### DIFF
--- a/operator/images/cluster-setup/content/bin/install.sh
+++ b/operator/images/cluster-setup/content/bin/install.sh
@@ -143,6 +143,13 @@ install_clusters() {
     check_statefulsets "tekton-results" "${resultsStatefulsets[@]}" | indent 4
     chainsDeployments=("tekton-chains-controller")
     check_deployments "tekton-chains" "${chainsDeployments[@]}" | indent 4
+
+    printf -- "- Checking pods status for controlplane namespaces\n"
+    # list of control plane namespaces
+    CONTROL_PLANE_NS=("openshift-apiserver" "openshift-controller-manager" "openshift-etcd" "openshift-ingress" "openshift-kube-apiserver" "openshift-kube-controller-manager" "openshift-kube-scheduler")
+    for ns in "${CONTROL_PLANE_NS[@]}"; do
+      check_crashlooping_pods "$ns" | indent 4
+    done
   done
 }
 


### PR DESCRIPTION
While installing pipeline service, we want to check the control plane pods to be in running state and avoid crashlooping or ci should fail. some verification checks for [issue](https://issues.redhat.com/browse/PLNSRVCE-1284) has already been addressed via 
PR : https://github.com/openshift-pipelines/pipeline-service/pull/582 and https://github.com/openshift-pipelines/pipeline-service/pull/605 
Uncovered checks will be verified with this pr

Signed-off-by: Priti Kumari [pkumari@redhat.com](mailto:pkumari@redhat.com) 