### PR TITLE
Rename pipelines-scc to appstudio-pipelines-scc

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/appstudio-pipelines-scc.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/appstudio-pipelines-scc.yaml
@@ -1,7 +1,7 @@
 ---
 kind: SecurityContextConstraints
 metadata:
-  name: pipelines-scc
+  name: appstudio-pipelines-scc
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - allow-argocd-to-manage.yaml
-  - pipelines-scc.yaml
+  - appstudio-pipelines-scc.yaml
   - openshift-operator.yaml
   - tekton-config.yaml
   - config-logging.yaml


### PR DESCRIPTION
The name is conflicting with the SCC created by OSP, and triggered the RHTAPBUGS-304 issue.