### PR TITLE
Upgrade PaC version to 0.17.3

### DIFF
--- a/operator/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
@@ -6,19 +6,19 @@ commonLabels:
 
 resources:
   - allow-argocd.yaml
-  - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.16.0/release.yaml
+  - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.17.3/release.yaml
 
 # TODO backing off until https://issues.redhat.com/browse/SRVKP-3134 is resolved
 # images:
-#  - name: ghcr.io/openshift-pipelines/pipelines-as-code-controller:v0.16.0
+#  - name: ghcr.io/openshift-pipelines/pipelines-as-code-controller:v0.17.3
 #    newName: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8
-#    newTag: v1.10.2-1
-#  - name: ghcr.io/openshift-pipelines/pipelines-as-code-watcher:v0.16.0
+#    newTag: v1.10.3-2
+#  - name: ghcr.io/openshift-pipelines/pipelines-as-code-watcher:v0.17.3
 #    newName: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8
-#    newTag: v1.10.2-1
-#  - name: ghcr.io/openshift-pipelines/pipelines-as-code-webhook:v0.16.0
+#    newTag: v1.10.3-2
+#  - name: ghcr.io/openshift-pipelines/pipelines-as-code-webhook:v0.17.3
 #    newName: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8
-#    newTag: v1.10.2-1
+#    newTag: v1.10.3-2
 
 patchesStrategicMerge:
   - disable-pipelines-as-code-webhook.yaml


### PR DESCRIPTION
As we are working through issues to migrate to the downstream images, the PaC version has been left
unchanged.

There has been quite a few bug fixes that have
been delivered that would improve the UX of
RHTAP, therefore an update seems warranted.

The version has been chosen to be compatible with
OSP 1.10, so as not to impact the image migration.