### PR TITLE
Remove usage of chains-ca-cert

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-chains/chains-controller-deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/chains-controller-deployment.yaml
@@ -1,8 +1,6 @@
 ---
 ########################
-# Mount the secrets volume where chains CA cert is located
-########################
-# Apply operator security standards (drop capabilities, resourece limits, run as non root, etc)
+# Apply operator security standards (drop capabilities, run as non root, etc)
 ########################
 #
 # The default install of chains includes the following
@@ -24,16 +22,12 @@ metadata:
   name: tekton-chains-controller
   namespace: tekton-chains
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   template:
     spec:
       containers:
         - name: tekton-chains-controller
-          volumeMounts:
-            # Mount the secrets volume
-            - mountPath: /etc/ssl/certs
-              name: chains-ca-cert
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -45,7 +39,3 @@ spec:
             seccompProfile:
               type: RuntimeDefault
             readOnlyRootFilesystem: true
-      volumes:
-        - name: chains-ca-cert
-          secret:
-            secretName: chains-ca-cert

--- a/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-config.yaml
@@ -1,12 +1,5 @@
 ---
 apiVersion: v1
-kind: Secret
-metadata:
-  name: chains-ca-cert
-  namespace: tekton-chains
-type: Opaque
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: chains-secrets-admin
@@ -22,7 +15,6 @@ rules:
       - ""
     resources:
       - secrets
-      - configmaps
     verbs:
       - list
       - create
@@ -74,51 +66,6 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: chains-certs-configuration
-  namespace: tekton-chains
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
-spec:
-  template:
-    spec:
-      containers:
-        - image: registry.redhat.io/openshift4/ose-cli:v4.12@sha256:9f0cdc00b1b1a3c17411e50653253b9f6bb5329ea4fb82ad983790a6dbf2d9ad
-          command:
-            - /bin/bash
-            - -c
-            - |
-              echo "Waiting for secret and configmaps to be present"
-              until oc get secret chains-ca-cert -n tekton-chains &&\
-                oc get cm config-trusted-cabundle -n tekton-chains &&\
-                oc get cm kube-root-ca.crt -n tekton-chains
-              do
-                sleep 5;
-              done
-
-              # Update the chains-ca-cert secret with cluster certs, trusted-ca's and ingress cert.
-              # The configmaps are injected by the Cluster Network Operator.
-              # Once https://github.com/tektoncd/operator/pull/648 changes are released, we can remove/review this hook.
-              echo "Build the certificate and replace secret/chains-ca-cert"
-              TRUSTED_CA=$(mktemp)
-              KUBE_CA=$(mktemp)
-              INGRESS_CA=$(mktemp)
-              oc get cm config-trusted-cabundle -n tekton-chains -o jsonpath="{.data.ca-bundle\.crt}" > $TRUSTED_CA
-              oc get cm kube-root-ca.crt -n tekton-chains -o jsonpath="{.data.ca\.crt}" > $KUBE_CA
-              oc get secret router-ca -n openshift-ingress-operator -o jsonpath="{.data.tls\.crt}" | base64 -d > $INGRESS_CA
-              SERVICE_CA=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-              cat $TRUSTED_CA $KUBE_CA $INGRESS_CA $SERVICE_CA > /tmp/ca-certificates.crt
-              oc create secret generic chains-ca-cert --from-file=/tmp/ca-certificates.crt --dry-run=client -o yaml -n tekton-chains | oc apply --force-conflicts --server-side=true -f -
-          imagePullPolicy: Always
-          name: patch-chains-certs
-      dnsPolicy: ClusterFirst
-      restartPolicy: OnFailure
-      terminationGracePeriodSeconds: 30
-      serviceAccount: chains-secrets-admin
-      serviceAccountName: chains-secrets-admin
----
-apiVersion: batch/v1
-kind: Job
-metadata:
   name: tekton-chains-signing-secret
   namespace: tekton-chains
   annotations:
@@ -156,38 +103,6 @@ spec:
                 )" \
                 --dry-run=client \
                 -o yaml | kubectl apply -f -
-      dnsPolicy: ClusterFirst
-      restartPolicy: OnFailure
-      terminationGracePeriodSeconds: 30
-      serviceAccount: chains-secrets-admin
-      serviceAccountName: chains-secrets-admin
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: tekton-chains-trusted-cabundle
-  namespace: tekton-chains
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
-spec:
-  template:
-    spec:
-      containers:
-        - name: config-trusted-cabundle-generation
-          image: registry.redhat.io/openshift4/ose-cli:v4.12@sha256:9f0cdc00b1b1a3c17411e50653253b9f6bb5329ea4fb82ad983790a6dbf2d9ad
-          imagePullPolicy: Always
-          command:
-            - /bin/bash
-            - -c
-            - |
-              if oc get cm config-trusted-cabundle -n tekton-chains; then
-                echo "ConfigMap config-trusted-cabundle found"
-              else
-                echo "Create ConfigMap config-trusted-cabundle"
-                oc create configmap config-trusted-cabundle --namespace tekton-chains
-                oc label configmap config-trusted-cabundle config.openshift.io/inject-trusted-cabundle="true"
-              fi
-              echo "Done"
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
The chains-ca-cert ConfigMap was introduced in order to allow the Tekton Chains controller to push content to the integrated OpenShift registry. Since then, we have moved away from using this registry altogether in favor of quay.io.

This change removes usage of the chains-ca-cert ConfigMap as well as the ArgoCD Jobs responsible for setting it up.

https://github.com/openshift-pipelines/pipeline-service/pull/673