### PR TITLE
PLNSRVCE-1310: bump exporter mem from 256 to 512 Mib

### DIFF
--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
@@ -25,6 +25,6 @@ spec:
               memory: "128Mi"
               cpu: "250m"
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "500m"
       restartPolicy: Always


### PR DESCRIPTION
Have pattern where the exporter in production hovers around 256 MiB for several hours, and when we bump up too much against it, the kubelet restarts us.  No error message in prev log.  So consistent with mem limit rebump.

Going to 512 to start.

As point of ref, tekton pipeline controller in production is hovering around 1GiB (and it has no mem limit).

We watch less that ^^ so let's see the 512 run first.