### PR TITLE
PLNSRVCE-1069:  get exporter metrics to work from dashboards

### DIFF
--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
@@ -20,6 +20,7 @@ spec:
           image: quay.io/redhat-appstudio/pipeline-service-exporter:placeholder
           ports:
             - containerPort: 9117
+              name: metrics
           resources:
             requests:
               memory: "128Mi"

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - clusterrolebinding.yaml
   - deployment.yaml
   - service.yaml
+  - servicemonitor.yaml
 
 images:
   - name: quay.io/redhat-appstudio/pipeline-service-exporter

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/servicemonitor.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/servicemonitor.yaml
@@ -1,0 +1,21 @@
+---
+# for RHTAP, the pipeline-service monitor is defined in infra-deployments, but we define here in our developer folder (vs. the operator folder) to define this out of dev_setup.sh
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pipeline-service
+  namespace: openshift-pipelines
+spec:
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+      - openshift-pipelines
+  endpoints:
+    - path: /metrics
+      port: metrics
+      interval: 15s
+      scheme: http
+      honorLabels: true
+  selector:
+    matchLabels:
+      app: pipeline-metrics-exporter


### PR DESCRIPTION
These are the changes I needed to get the pipeline-service-exporter metrics to be visible from the grafana dashboards.

Turns out we need to move the servicemonitor def from infra-deployments to this repo

A couple of minor selector labeling tweaks on top.

