### PR TITLE
assign values to  `sync-wave`explicitly in manifests

### DIFF
--- a/developer/openshift/gitops/argocd/pipeline-service-o11y.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: pipeline-service-o11y
   namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   destination:
     namespace: openshift-gitops

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/allow-argocd-to-manage.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/allow-argocd-to-manage.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: openshift-gitops-apply-grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - integreatly.org
@@ -22,6 +24,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: openshift-gitops-apply-grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -36,6 +40,8 @@ kind: Role
 metadata:
   name: openshift-gitops-manage-grafana
   namespace: appstudio-grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - ""
@@ -67,6 +73,8 @@ kind: RoleBinding
 metadata:
   name: openshift-gitops-manage-grafana
   namespace: appstudio-grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/namespace.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/namespace.yaml
@@ -3,4 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: appstudio-grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec: {}

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-prometheus/allow-argocd-to-manage.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-prometheus/allow-argocd-to-manage.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: openshift-gitops-apply-prometheus
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - monitoring.rhobs
@@ -32,6 +34,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: openshift-gitops-apply-prometheus
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -46,6 +50,8 @@ kind: Role
 metadata:
   name: openshift-gitops-manage-secrets
   namespace: o11y
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - ""
@@ -64,6 +70,8 @@ kind: RoleBinding
 metadata:
   name: openshift-gitops-manage-secrets
   namespace: o11y
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/developer/openshift/gitops/argocd/pipeline-service-storage.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-storage.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: pipeline-service-storage
   namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   destination:
     namespace: openshift-gitops

--- a/developer/openshift/gitops/argocd/pipeline-service-storage/minio/operator/allow-argocd-to-manage.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-storage/minio/operator/allow-argocd-to-manage.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: openshift-minio-apply-tenants
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - minio.min.io
@@ -32,6 +34,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: openshift-minio-apply-tenants
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/developer/openshift/gitops/argocd/pipeline-service-storage/minio/operator/minio.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-storage/minio/operator/minio.yaml
@@ -4,6 +4,8 @@ kind: Subscription
 metadata:
   name: minio-operator
   namespace: openshift-operators
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   channel: stable
   installPlanApproval: Automatic

--- a/developer/openshift/gitops/argocd/pipeline-service-storage/minio/tenant/tenant.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-storage/minio/tenant/tenant.yaml
@@ -11,6 +11,7 @@ metadata:
     prometheus.io/port: "9000"
     prometheus.io/scrape: "true"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   exposeServices:
     minio: true

--- a/developer/openshift/gitops/argocd/pipeline-service-storage/postgres.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-storage/postgres.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: postgres
   namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   project: default
   destination:

--- a/developer/openshift/gitops/argocd/pipeline-service.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: pipeline-service
   namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   destination:
     namespace: openshift-gitops

--- a/developer/openshift/gitops/argocd/pipeline-service/tekton-results/minio-create-bucket.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service/tekton-results/minio-create-bucket.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: tekton-results-api
   namespace: tekton-results
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   template:
     spec:

--- a/developer/openshift/gitops/argocd/pipeline-service/tekton-results/minio-tls.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service/tekton-results/minio-tls.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: tekton-results-api
   namespace: tekton-results
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   template:
     spec:

--- a/developer/openshift/operators/openshift-gitops/openshift-gitops.yaml
+++ b/developer/openshift/operators/openshift-gitops/openshift-gitops.yaml
@@ -4,6 +4,8 @@ kind: Subscription
 metadata:
   name: openshift-gitops-operator
   namespace: openshift-operators
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   channel: stable
   installPlanApproval: Automatic

--- a/operator/gitops/argocd/grafana/dashboard.yaml
+++ b/operator/gitops/argocd/grafana/dashboard.yaml
@@ -5,6 +5,8 @@ metadata:
   name: grafana-dashboard-pipeline-service
   labels:
     app: appstudio-grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   configMapRef:
     name: grafana-dashboard-pipeline-service

--- a/operator/gitops/argocd/pipeline-service.yaml
+++ b/operator/gitops/argocd/pipeline-service.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: pipeline-service
   namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   destination:
     namespace: openshift-gitops

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrole.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrole.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: pipeline-service-exporter-reader
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups: [""]
     resources: ["pods", "services", "namespaces", "endpoints"]

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrolebinding.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrolebinding.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pipeline-service-exporter-reader-binding
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: pipeline-metrics-exporter
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: 1
   selector:

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/service.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/service.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: openshift-pipelines
   labels:
     app: pipeline-metrics-exporter
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   selector:
     app: pipeline-metrics-exporter

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/serviceaccount.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/serviceaccount.yaml
@@ -4,3 +4,5 @@ kind: ServiceAccount
 metadata:
   name: pipeline-service-exporter
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/servicemonitor.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/servicemonitor.yaml
@@ -5,6 +5,8 @@ kind: ServiceMonitor
 metadata:
   name: pipeline-service
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   jobLabel: app
   namespaceSelector:

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/allow-argocd-to-manage.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/allow-argocd-to-manage.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: openshift-gitops-apply-tekton-config-parameters
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - monitoring.coreos.com
@@ -39,6 +41,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: openshift-gitops-apply-tekton-config-parameters
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/appstudio-pipelines-scc.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/appstudio-pipelines-scc.yaml
@@ -2,6 +2,8 @@
 kind: SecurityContextConstraints
 metadata:
   name: appstudio-pipelines-scc
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/config-logging.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/config-logging.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: default
     operator.tekton.dev/operand-name: tektoncd-pipelines
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "1"
 data:
   zap-logger-config: |
     {

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/config-pac.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/config-pac.yaml
@@ -8,6 +8,8 @@ kind: ConfigMap
 metadata:
   name: pipelines-as-code
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 data:
   # The application name, you can customize this label. If using the Github App you will need to customize the label on the github app setting as well.
   application-name: "Pipelines as Code CI"

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/openshift-operator.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/openshift-operator.yaml
@@ -4,6 +4,8 @@ kind: Subscription
 metadata:
   name: openshift-pipelines-operator
   namespace: openshift-operators
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   channel: pipelines-1.11
   name: openshift-pipelines-operator-rh

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -8,6 +8,7 @@ metadata:
     # This Argo CD annotation ensures that Argo CD will skip the dry if the resource is not yet known to the cluster,
     # the CRD will be applied and the resource can be created once the required dependencies are met.
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   params:
     - name: createRbacResource

--- a/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-config.yaml
@@ -4,12 +4,16 @@ kind: ServiceAccount
 metadata:
   name: chains-secrets-admin
   namespace: tekton-chains
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: chains-secret-admin
   namespace: tekton-chains
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - ""
@@ -27,6 +31,8 @@ kind: Role
 metadata:
   name: secret-reader
   namespace: openshift-ingress-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - ""
@@ -40,6 +46,8 @@ kind: RoleBinding
 metadata:
   name: chains-secret-admin
   namespace: tekton-chains
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -54,6 +62,8 @@ kind: RoleBinding
 metadata:
   name: chains-secret-reader
   namespace: openshift-ingress-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-migration.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/chains-secrets-migration.yaml
@@ -4,11 +4,15 @@ kind: ServiceAccount
 metadata:
   name: tekton-chains-secrets-migrator
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: tekton-chains-secret-migration
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - ""
@@ -25,6 +29,8 @@ kind: RoleBinding
 metadata:
   name: tekton-chains-secrets-migrator
   namespace: tekton-chains
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -39,6 +45,8 @@ kind: Role
 metadata:
   name: openshift-pipelines-secret-migration
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - ""
@@ -57,6 +65,8 @@ kind: RoleBinding
 metadata:
   name: openshift-pipelines-secret-migration
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -70,6 +80,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: openshift-gitops-jobs-admin
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - batch
@@ -86,6 +98,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: openshift-gitops-jobs-admin
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -166,6 +180,8 @@ kind: RoleBinding
 metadata:
   name: openshift-pipelines-public-key-viewer
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/operator/gitops/argocd/pipeline-service/tekton-chains/namespace.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: tekton-chains
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/operator/gitops/argocd/pipeline-service/tekton-chains/public-key.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/public-key.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: tekton-chains-public-key-viewer
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - apiGroups:
       - ""
@@ -20,6 +22,8 @@ kind: RoleBinding
 metadata:
   name: tekton-chains-public-key-viewer
   namespace: tekton-chains
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-db-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-db-config.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: tekton-results-api
   namespace: tekton-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   template:
     spec:

--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-migrator-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-migrator-config.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: tekton-results-api
   namespace: tekton-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   template:
     spec:

--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-route.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-route.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     openshift.io/host.generated: "true"
     haproxy.router.openshift.io/hsts_header: "max-age=63072000"
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   to:
     kind: Service

--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-s3-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-s3-config.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: tekton-results-api
   namespace: tekton-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   template:
     spec:

--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-service-tls.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-service-tls.yaml
@@ -6,3 +6,4 @@ metadata:
   namespace: tekton-pipelines
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
+    argocd.argoproj.io/sync-wave: "0"

--- a/operator/gitops/argocd/pipeline-service/tekton-results/namespace.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: tekton-results
   labels:
     argocd.argoproj.io/managed-by: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/operator/gitops/argocd/pipeline-service/tekton-results/service-monitor.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/service-monitor.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: metrics-reader
   namespace: tekton-results
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 ---
 apiVersion: v1
 kind: Secret
@@ -12,12 +14,15 @@ metadata:
   namespace: tekton-results
   annotations:
     kubernetes.io/service-account.name: metrics-reader
+    argocd.argoproj.io/sync-wave: "0"
 type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: tekton-results-service-metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 rules:
   - nonResourceURLs:
       - /metrics
@@ -28,6 +33,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-tekton-results-service-metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -42,6 +49,8 @@ kind: ServiceMonitor
 metadata:
   name: tekton-results-api
   namespace: tekton-results
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   endpoints:
     - path: /metrics
@@ -61,6 +70,8 @@ kind: ServiceMonitor
 metadata:
   name: tekton-results-watcher
   namespace: tekton-results
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   endpoints:
     - path: /metrics

--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   name: tekton-results-watcher
   namespace: tekton-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   template:
     spec:

--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-logging-rbac.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-logging-rbac.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-results-watcher-logs
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 subjects:
   - kind: ServiceAccount
     name: tekton-results-watcher

--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-logging.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-logging.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: tekton-results-config-logging
   namespace: tekton-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 data:
   # Adjust zap-logger config according to ADR 6
   zap-logger-config: |


### PR DESCRIPTION
#### This pull request introduces an explicit assignment of the default value (0) for sync-waves in our GitOps workflow. Currently, sync-waves are automatically allocated with a default value, but this change aims to enhance code readability and maintainability.