### PR TITLE
Inner Loop Observability with Prometheus and Grafana

### DIFF
--- a/developer/openshift/dev_setup.sh
+++ b/developer/openshift/dev_setup.sh
@@ -241,7 +241,7 @@ install_pipeline_service() {
 
   # Patch the url/branch to target the expected repository/branch
   manifest_dir="$(find "$WORK_DIR/environment/compute" -mindepth 1 -maxdepth 1 -type d)"
-  for app in "pipeline-service" "pipeline-service-storage"; do
+  for app in "pipeline-service" "pipeline-service-storage" "pipeline-service-o11y"; do
     cat << EOF >"$manifest_dir/patch-$app.yaml"
 ---
 apiVersion: argoproj.io/v1alpha1

--- a/developer/openshift/gitops/argocd/kustomization.yaml
+++ b/developer/openshift/gitops/argocd/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - pipeline-service.yaml
   - pipeline-service-storage.yaml
+  - pipeline-service-o11y.yaml

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pipeline-service-o11y
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  source:
+    path: developer/openshift/gitops/argocd/pipeline-service-o11y
+    repoURL: https://github.com/openshift-pipelines/pipeline-service.git
+    targetRevision: main
+  project: default
+  syncPolicy:
+    # Comment this out if you want to manually trigger deployments (using the
+    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+    # every new Git commit to your directory.
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: -1 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 10s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+        factor: 2 # a factor to multiply the base duration after each failed retry
+        maxDuration: 3m # the maximum amount of time allowed for the backoff strategy

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/README.md
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/README.md
@@ -1,5 +1,40 @@
 # Pipeline Service Observability
 
-This deploys observability (o11y) components used to configure Prometheus.
-It utilizes the o11y stack from redhat-appstudio, with modifications to only deploy
-what is needed by the Pipeline Service for inner-loop development.
+This deploys observability (o11y) components used to configure Prometheus and
+Grafana. It utilizes the o11y stack from redhat-appstudio, with modifications
+to only deploy what is needed by the Pipeline Service for GitOps-based
+development.
+
+## GitOps Inner Loop Development
+
+The `dev_setup.sh` configures Prometheus and Grafana to deploy the Pipeline
+Service dashboards. Grafana's UI can be accessed at the
+`grafana-access-appstudio-grafana.apps...` route on your cluster.
+
+To iterate on your dashboard (deploying with `--use-current-branch`):
+
+1. Navigate to the Pipeline Service dashboard in Grafana.
+2. Add the panels and/or rows for your metrics as desired.
+3. Click the "Share" icon to save the dashboard to JSON.
+4. Copy the JSON into the pipeline-service-dashboard.json file, located in
+   `operator/gitops/argocd/grafana/dashboards`.
+5. Commit the updated JSON, push to your branch, and verify the dashboard is
+   updated once ArgoCD syncs your repository.
+
+## Components
+
+### appstudio-prometheus
+
+This configures the Red Hat
+[Observability Operator](https://github.com/rhobs/observability-operator) using
+the same manifests used by App Studio. The operator consolidates the "cluster
+monitoring" and "user workload" monitoring stacks, allowing metrics to combined
+in a single data source view.
+
+### appstudio-grafana
+
+This configures the [Grafana Operator](https://github.com/grafana-operator/grafana-operator)
+using the same manifests as App Studio. The operator deploys and manages
+Grafana instances, and lets dashboards be configured with custom resources and
+JSON stored in ConfigMaps. The deployment includes the Pipeline Service
+dashboard, which is referenced in-tree.

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/README.md
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/README.md
@@ -1,0 +1,5 @@
+# Pipeline Service Observability
+
+This deploys observability (o11y) components used to configure Prometheus.
+It utilizes the o11y stack from redhat-appstudio, with modifications to only deploy
+what is needed by the Pipeline Service for inner-loop development.

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/allow-argocd-to-manage.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/allow-argocd-to-manage.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-gitops-apply-grafana
+rules:
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - grafanas
+      - grafanadashboards
+      - grafanadatasources
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-gitops-apply-grafana
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-gitops-apply-grafana
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-gitops-manage-grafana
+  namespace: appstudio-grafana
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-gitops-manage-grafana
+  namespace: appstudio-grafana
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-gitops-manage-grafana
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/kustomization.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - allow-argocd-to-manage.yaml
+  - namespace.yaml
+  - https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/monitoring/grafana/base/grafana-operator.yaml
+  - https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/monitoring/grafana/base/grafana-app.yaml
+  - ../../../../../../operator/gitops/argocd/grafana
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+namespace: appstudio-grafana
+configurations:
+  - https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/monitoring/grafana/base/cm-dashboard.yaml

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/namespace.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-grafana
+spec: {}

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-prometheus/allow-argocd-to-manage.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-prometheus/allow-argocd-to-manage.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-gitops-apply-prometheus
+rules:
+  - apiGroups:
+      - monitoring.rhobs
+    resources:
+      - monitoringstacks
+      - servicemonitors
+    verbs:
+      - get
+      - list
+      - patch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - patch
+      - create
+      - update
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-gitops-apply-prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-gitops-apply-prometheus
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-gitops-manage-secrets
+  namespace: o11y
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-gitops-manage-secrets
+  namespace: o11y
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-gitops-manage-secrets
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-prometheus/kustomization.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-prometheus/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - allow-argocd-to-manage.yaml
+  - https://github.com/redhat-appstudio/infra-deployments/components/o11y/development?ref=main
+  - https://github.com/redhat-appstudio/infra-deployments/components/monitoring/prometheus/development?ref=main

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/kustomization.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - appstudio-prometheus

--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/kustomization.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - appstudio-prometheus
+  - appstudio-grafana


### PR DESCRIPTION
Enhance our dev setup flow by allowing developers to do "Gitops Inner Loop" development with Prometheus and Grafana. This is provided by an ArgoCD application that deploys a slimmed down version of the App Studio Prometheus and Grafana observability stacks. The dashboards for Pipeline Service are referenced "in-tree", which allows team members to iterate via GitOps (per our usual development flow).
