### PR TITLE
Manually Enable pac controller metrics for pipeline-service

### DIFF
--- a/operator/gitops/argocd/pipeline-service/pipelines-as-code/controller-service-update.yaml
+++ b/operator/gitops/argocd/pipeline-service/pipelines-as-code/controller-service-update.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pipelines-as-code-controller
+  namespace: pipelines-as-code
+  labels:
+    app: pipelines-as-code-controller
+spec:
+  ports:
+    - name: http-metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090

--- a/operator/gitops/argocd/pipeline-service/pipelines-as-code/controller-sync.yaml
+++ b/operator/gitops/argocd/pipeline-service/pipelines-as-code/controller-sync.yaml
@@ -6,3 +6,19 @@ metadata:
   namespace: pipelines-as-code
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+spec:
+  template:
+    metadata:
+      labels:
+        app: pipelines-as-code-controller
+    spec:
+      containers:
+        - name: pac-controller
+          ports:
+            - name: metrics
+              containerPort: 9090
+          env:
+            - name: K_METRICS_CONFIG
+              value: '{"Domain":"pipelinesascode.tekton.dev/controller","Component":"pac_controller","PrometheusPort":9090,"ConfigMap":{"name":"pipelines-as-code-config-observability"}}'
+            - name: K_TRACING_CONFIG
+              value: '{"backend":"prometheus","debug":"false","sample-rate":"0"}'

--- a/operator/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/pipelines-as-code/kustomization.yaml
@@ -24,6 +24,7 @@ patchesStrategicMerge:
   - disable-pipelines-as-code-webhook.yaml
   - controller-sync.yaml
   - watcher-sync.yaml
+  - controller-service-update.yaml
 
 patchesJson6902:
   - target:


### PR DESCRIPTION
- Add metrics domain and observability configmap to the controller deployment
- Update the `pipelines-as-code-controller` service with metrics port
- Revert the flow to original, once we have [PR](https://github.com/openshift-pipelines/pipelines-as-code/pull/1328) GA

Signed-off-by: Priti Kumari [pkumari@redhat.com](mailto:pkumari@redhat.com)

