### PR TITLE
PLNSRVCE-1105: re-enable PaC job to update infra-deployments on merge

### DIFF
--- a/.tekton/infra-deployment-push.yaml
+++ b/.tekton/infra-deployment-push.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: pipeline-service-push
+  name: pipeline-service-infra-deployment-update
   annotations:
     pipelinesascode.tekton.dev/on-event: "push"
     pipelinesascode.tekton.dev/on-target-branch: "main"
@@ -17,6 +17,7 @@ spec:
       value: |
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/development/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/staging/base/kustomization.yaml
+        sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/monitoring/grafana/base/pipeline-service/kustomization.yaml
   pipelineSpec:
     params:
       - description: 'Source Repository URL'


### PR DESCRIPTION
With @xinredhat move our our CI to RHTAP, the boiler plate all the other repos use should in theory work again, so re-enabling / modernizing our previous attempt