### PR TITLE
Stop producing TaskRun attestations

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-chains/chains-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-chains/chains-config.yaml
@@ -8,9 +8,11 @@ metadata:
 data:
   # See https://tekton.dev/docs/chains/config/
 
-  # Configure TaskRun attestation
+  # Configure TaskRun attestation. RHTAP does not leverage the TaskRun
+  # attestations. This tells Tekton Chains to not store them in the OCI
+  # registry.
   artifacts.taskrun.format: "in-toto"
-  artifacts.taskrun.storage: "oci"
+  artifacts.taskrun.storage: ""
 
   # Configure PipelineRun attestation
   artifacts.pipelinerun.format: "in-toto"


### PR DESCRIPTION
https://issues.redhat.com/browse/HACBS-2209

RHTAP is only concerned with PipelineRun attestations. The TaskRun attestations add noise and potential confusion to users. Also, the PipelineRun attestation already contains all the data found on the TaskRun attestation.