### PR TITLE
PLNSRVCE-1350: add pipelines-as-code configmap to gitops tree to allow RHTAP to gitopos patch

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/config-pac.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/config-pac.yaml
@@ -1,0 +1,13 @@
+---
+# we need the pac config map in the gitops tree so that we can then patch it with RHTAP specific updates
+# previously, when pipeline-service deployed pac via the upstream yaml, that is how the config map got into
+# the gitops tree, but now that we are allowing openshift-pipelines operator install pac, we need to create
+# this empty config map
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pipelines-as-code
+  namespace: openshift-pipelines
+data:
+  # The application name, you can customize this label. If using the Github App you will need to customize the label on the github app setting as well.
+  application-name: "Pipelines as Code CI"

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - appstudio-pipelines-scc.yaml
   - openshift-operator.yaml
   - tekton-config.yaml
+  - config-pac.yaml
   - config-logging.yaml


### PR DESCRIPTION
As part of getting the 1.11 bump working into staging, I discovered that the patch of the `pipelines-as-code` configmap at https://github.com/redhat-appstudio/infra-deployments/blob/main/components/pipeline-service/staging/base/kustomization.yaml#L23-L27 and https://github.com/redhat-appstudio/infra-deployments/blob/main/components/pipeline-service/staging/base/pac-app-name.yaml was not taking hold.

As @Michkov made me realize, we cannot do a gitops patch of an object if gitops did not create the object.

This is not happening with the 1.11 bump as we have openshift pipelines operator creating pac vs. the pipeline service gitops based deploy of pac from the upstream release.

This change now creates the config map as part of our gitops tree (similar to what we are doing with the logging config map), so that we can then later patch the configmay in infra deployments.