### PR TITLE
Increased pipeline timeout

### DIFF
--- a/.tekton/pipeline-service-test.yaml
+++ b/.tekton/pipeline-service-test.yaml
@@ -31,7 +31,7 @@ spec:
     - name: target_branch
       value: "{{ target_branch }}"
   timeouts:
-    pipeline: "1h0m0s"
+    pipeline: "1h30m0s"
   workspaces:
     - name: source
       volumeClaimTemplate:

--- a/.tekton/pipeline-service-upgrade-test.yaml
+++ b/.tekton/pipeline-service-upgrade-test.yaml
@@ -32,7 +32,7 @@ spec:
     - name: target_branch
       value: "{{ target_branch }}"
   timeouts:
-    pipeline: "1h0m0s"
+    pipeline: "1h30m0s"
   workspaces:
     - name: source
       volumeClaimTemplate:

--- a/.tekton/pipeline/acceptance-tests.yaml
+++ b/.tekton/pipeline/acceptance-tests.yaml
@@ -11,7 +11,7 @@ spec:
     - name: target_branch
     - name: ocp_version
   timeouts:
-    finally: "0h20m0s"
+    finally: "0h30m0s"
   workspaces:
     - name: source
     - name: shared-workspace

--- a/.tekton/pipeline/stonesoup-integeration-tests.yaml
+++ b/.tekton/pipeline/stonesoup-integeration-tests.yaml
@@ -5,7 +5,7 @@ metadata:
   name: stonesoup-integeration-tests
 spec:
   timeouts:
-    finally: "0h20m0s"
+    finally: "0h30m0s"
   params:
     - name: aws_region
     - name: ocp_version

--- a/.tekton/pipeline/upgrade-tests.yaml
+++ b/.tekton/pipeline/upgrade-tests.yaml
@@ -11,7 +11,7 @@ spec:
     - name: revision
     - name: target_branch
   timeouts:
-    finally: "0h20m0s"
+    finally: "0h30m0s"
   workspaces:
     - name: source
     - name: upgrade-shared-workspace


### PR DESCRIPTION
Increase the timeout limit for PipelineRuns to avoid CI timeout failure. The main reason is that ROSA Hypershift creation/deletion is not stable, sometimes they need longer time than 15 mins we expected. 