### PR TITLE
fix(RHTAPWATCH-8): Update GrafanaDashboard to match GrafanaOperator v5

### DIFF
--- a/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/kustomization.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service-o11y/appstudio-grafana/kustomization.yaml
@@ -11,4 +11,4 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 namespace: appstudio-grafana
 configurations:
-  - https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/monitoring/grafana/base/cm-dashboard.yaml
+  - https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/monitoring/grafana/base/dashboards/cm-dashboard.yaml

--- a/operator/gitops/argocd/grafana/dashboard.yaml
+++ b/operator/gitops/argocd/grafana/dashboard.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-pipeline-service
@@ -8,6 +8,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-pipeline-service
     key: pipeline-service-dashboard.json


### PR DESCRIPTION
As part of this bug fix and the upgrade to `GrafanaOperator` v5, we have to update the `GrafanaDashboard` resource to match the new api

More details:
https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1690371680784569

The dashboard is still presenting data due to a patch we merged to RHTAP, and it will be removed after these changes will be merged