### PR TITLE
Refactor update-dependencies 1/2

### DIFF
--- a/.tekton/pipeline/update-repository.yaml
+++ b/.tekton/pipeline/update-repository.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: update-repository
+spec:
+  params:
+    - name: repo_name
+    - name: repo_owner
+    - name: repo_url
+    - name: source_branch
+  workspaces:
+    - name: workdir
+  tasks:
+    - name: update-binaries
+      taskRef:
+        name: update-repository
+      params:
+        - name: COMMIT_BRANCH
+          value: "robot/$(params.source_branch)/update_binaries"
+        - name: TARGET_GH_NAME
+          value: $(params.repo_name)
+        - name: TARGET_GH_OWNER
+          value: $(params.repo_owner)
+        - name: TARGET_GH_URL
+          value: $(params.repo_url)
+        - name: TARGET_BRANCH
+          value: $(params.source_branch)
+        - name: SCRIPT_IMAGE
+          value: quay.io/redhat-pipeline-service/dependencies-update:$(params.source_branch)
+        - name: SCRIPT_PATH
+          value: ./developer/images/dependencies-update/hack/bin/update.sh
+        - name: SCRIPT_ARGS
+          value:
+            - --task
+            - update_binaries
+            - --workspace_dir
+            - "."
+      workspaces:
+        - name: workdir
+          workspace: workdir
+    - name: update-images
+      runAfter:
+        - update-binaries
+      taskRef:
+        name: update-repository
+      params:
+        - name: COMMIT_BRANCH
+          value: "robot/$(params.source_branch)/update_dockerfiles"
+        - name: TARGET_GH_NAME
+          value: $(params.repo_name)
+        - name: TARGET_GH_OWNER
+          value: $(params.repo_owner)
+        - name: TARGET_GH_URL
+          value: $(params.repo_url)
+        - name: TARGET_BRANCH
+          value: $(params.source_branch)
+        - name: SCRIPT_IMAGE
+          value: quay.io/redhat-pipeline-service/dependencies-update:$(params.source_branch)
+        - name: SCRIPT_PATH
+          value: ./developer/images/dependencies-update/hack/bin/update.sh
+        - name: SCRIPT_ARGS
+          value:
+            - --task
+            - update_dockerfiles_base_images_sha
+            - --workspace_dir
+            - "."
+      workspaces:
+        - name: workdir
+          workspace: workdir

--- a/.tekton/tasks/update-repository.yaml
+++ b/.tekton/tasks/update-repository.yaml
@@ -1,0 +1,192 @@
+---
+# Based on: https://github.com/redhat-appstudio/build-definitions/blob/main/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio, hacbs"
+  name: update-repository
+spec:
+  description: |
+    Clones a repository, runs script in 'SCRIPT' parameter, and generates a pull-request to the repository if a change is detected.
+  params:
+    - name: COMMIT_BRANCH
+      description: Name of the branch which holds the update created by the Pipeline
+    - name: TARGET_BRANCH
+      description: Name of the branch which is modified by the Pipeline
+    - name: TARGET_GH_NAME
+      description: Name of the repository which is modified by the Pipeline
+    - name: TARGET_GH_OWNER
+      description: Owner of the repository which is modified by the Pipeline
+    - name: TARGET_GH_URL
+      description: URL of github repository which is modified by the Pipeline
+    - name: SCRIPT_IMAGE
+      description: Image reference used to execute the script
+    - name: SCRIPT_PATH
+      description: Path to the script updating the repository
+    - name: SCRIPT_ARGS
+      description: Arguments to the bash script
+      type: array
+    - name: shared-secret
+      default: infra-deployments-pr-creator
+      description: secret in the namespace which contains private key for the GitHub App
+    - name: GITHUB_APP_ID
+      description: ID of Github app used for updating PR
+      default: "305606"
+    - name: GITHUB_APP_INSTALLATION_ID
+      description: Installation ID of Github app in the organization
+      default: "35269675"
+    - name: GIT_IMAGE
+      description: Image reference containing the git command
+      default: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8
+    - name: GIT_USER
+      description: Username to appear in the commit
+      default: "Tekton CI"
+    - name: GIT_EMAIL
+      description: Email to appear in the commit
+      default: "tekton-ci@example.com"
+  volumes:
+    - name: infra-deployments-pr-creator
+      secret:
+        # 'private-key' - private key for Github app
+        secretName: $(params.shared-secret)
+  steps:
+    - name: git-clone-repository
+      image: $(params.GIT_IMAGE)
+      workingDir: $(workspaces.workdir.path)
+      env:
+        - name: TARGET_BRANCH
+          value: $(params.TARGET_BRANCH)
+        - name: TARGET_GH_NAME
+          value: $(params.TARGET_GH_NAME)
+        - name: TARGET_GH_OWNER
+          value: $(params.TARGET_GH_OWNER)
+        - name: TARGET_GH_URL
+          value: $(params.TARGET_GH_URL)
+      script: |
+        WORK_DIR="${PWD}/${TARGET_GH_OWNER}/${TARGET_GH_NAME}"
+        if [ -e "${WORK_DIR}" ]; then
+          echo "Clean checkout of '${TARGET_GH_URL}/${TARGET_BRANCH}' in '${WORK_DIR}'"
+          cd "${WORK_DIR}"
+          git clean -d --force
+          git reset --hard
+          git checkout "${TARGET_BRANCH}"
+        else
+          echo "Cloning '${TARGET_GH_URL}/${TARGET_BRANCH}' to '${WORK_DIR}'"
+          mkdir -p "$(dirname "${WORK_DIR}")"
+          cd "$(dirname "${WORK_DIR}")"
+          git clone --branch "${TARGET_BRANCH}" "${TARGET_GH_URL}" "${TARGET_GH_NAME}"
+        fi
+    - name: run-update-script
+      image: $(params.SCRIPT_IMAGE)
+      workingDir: $(workspaces.workdir.path)
+      env:
+        - name: COMMIT_BRANCH
+          value: $(params.COMMIT_BRANCH)
+        - name: GIT_EMAIL
+          value: $(params.GIT_EMAIL)
+        - name: GIT_USER
+          value: $(params.GIT_USER)
+        - name: SCRIPT_PATH
+          value: $(params.SCRIPT_PATH)
+        - name: TARGET_BRANCH
+          value: $(params.TARGET_BRANCH)
+        - name: TARGET_GH_NAME
+          value: $(params.TARGET_GH_NAME)
+        - name: TARGET_GH_OWNER
+          value: $(params.TARGET_GH_OWNER)
+      args: ["$(params.SCRIPT_ARGS[*])"]
+      script: |
+        #!/bin/bash
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        SCRIPT_ARGS=( "$@" )
+
+        # Go to repository directory
+        WORK_DIR="${PWD}/${TARGET_GH_OWNER}/${TARGET_GH_NAME}"
+        cd "${WORK_DIR}"
+        echo "${PWD}"
+
+        # Setup git
+        git config --global safe.directory "${PWD}"
+        git config --local user.email "$GIT_EMAIL"
+        git config --local user.name "$GIT_USER"
+
+        # Create branch
+        git branch --copy --force "$COMMIT_BRANCH"
+        git checkout "$COMMIT_BRANCH"
+
+        # Run script
+        UPSTREAM_COMMIT=$(git rev-parse HEAD)
+        "${SCRIPT_PATH}" "${SCRIPT_ARGS[@]}"
+
+        # Log changes
+        DATA=".commits.json"
+        cat << EOF > "$DATA"
+        {
+          "branch": {
+            "source": "$TARGET_BRANCH",
+            "source_sha": "$UPSTREAM_COMMIT",
+            "target": "$COMMIT_BRANCH"
+          },
+        EOF
+        echo -n '  "commits": [' >> "$DATA"
+
+        PREVIOUS_COMMIT=$UPSTREAM_COMMIT
+        HEAD=$(git rev-parse HEAD)
+        for COMMIT in $(git rev-list "$UPSTREAM_COMMIT..HEAD"); do
+            git checkout "$COMMIT"
+            if tail -1 "$DATA" | grep -q "}$" ; then
+                echo ","
+            else
+                echo
+            fi  >> "$DATA"
+            cat << EOF >> "$DATA"
+            {
+              "files": [
+        EOF
+            for FILE in $(git diff --name-only "$PREVIOUS_COMMIT..$COMMIT"); do
+                if tail -1 "$DATA" | grep -q "}$" ; then
+                    echo "," >> "$DATA"
+                fi
+                echo "        {" >> "$DATA"
+                if [ -e "$FILE" ]; then
+                    cat << EOF >> "$DATA"
+                  "content": "$(cat "$FILE" | base64 | tr -d "\n")",
+                  "mode": "$(git ls-files --format='%(objectmode)' "$FILE")",
+        EOF
+                fi
+                cat << EOF >> "$DATA"
+                  "path": "$FILE"
+        EOF
+                echo -n "        }" >> "$DATA"
+            done
+            MESSAGE=$(git log -1 --format="%B" "$COMMIT" | sed "s:$:\\\n:g" | tr -d "\n") 2>/dev/null
+            cat << EOF >> "$DATA"
+
+              ],
+              "message": "$MESSAGE"
+        EOF
+            echo -n "    }" >> "$DATA"
+        done
+        if tail -1 "$DATA" | grep -q "\[$" ; then
+            echo "],"
+        else
+            echo "
+          ],"
+        fi >> "$DATA"
+        cat << EOF >> "$DATA"
+          "user": {
+              "email": "$GIT_EMAIL",
+              "name": "$GIT_USER"
+            }
+        }
+        EOF
+  workspaces:
+    - name: workdir
+      description: Shared storage to keep a single copy of the repositories

--- a/.tekton/update-dependencies.yaml
+++ b/.tekton/update-dependencies.yaml
@@ -5,13 +5,16 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
-    pipelinesascode.tekton.dev/task: "[git-clone, github-open-pr]"
+    pipelinesascode.tekton.dev/pipeline: "[.tekton/pipeline/update-repository.yaml]"
+    pipelinesascode.tekton.dev/task-1: "[.tekton/tasks/update-repository.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
   name: pipeline-service-update-dependencies
 spec:
   timeouts:
     pipeline: "0h20m0s"
     tasks: "0h5m0s"
+  pipelineRef:
+    name: update-repository
   params:
     - name: repo_name
       value: "{{ repo_name }}"
@@ -21,219 +24,8 @@ spec:
       value: "{{ repo_url }}"
     - name: source_branch
       value: "{{ source_branch }}"
-  pipelineSpec:
-    params:
-      - name: repo_name
-      - name: repo_owner
-      - name: repo_url
-      - name: source_branch
-    workspaces:
-      - name: source
-    tasks:
-      - name: git-clone
-        taskRef:
-          name: git-clone
-          kind: Task
-        workspaces:
-          - name: output
-            workspace: source
-        params:
-          - name: url
-            value: $(params.repo_url)
-          - name: revision
-            value: "origin/$(params.source_branch)"
-          - name: refspec
-            value: "refs/heads/$(params.source_branch)"
-      - name: git-setup
-        runAfter:
-          - git-clone
-        workspaces:
-          - name: source
-            workspace: source
-        params:
-          - name: source_branch
-            value: $(params.source_branch)
-        taskSpec:
-          params:
-            - name: source_branch
-          steps:
-            - name: setup-local-repository
-              image: quay.io/redhat-pipeline-service/dependencies-update:$(params.source_branch)
-              imagePullPolicy: Always
-              workingDir: $(workspaces.source.path)
-              command:
-                - ./developer/images/dependencies-update/hack/bin/setup-local-repository.sh
-                - --debug
-                - --branch
-                - $(params.source_branch)
-          workspaces:
-            - name: source
-      - name: update-dockerfiles
-        runAfter:
-          - git-setup
-        workspaces:
-          - name: source
-            workspace: source
-        params:
-          - name: repo_name
-            value: $(params.repo_name)
-          - name: repo_owner
-            value: $(params.repo_owner)
-          - name: source_branch
-            value: $(params.source_branch)
-          - name: target_branch
-            value: "robot/$(params.source_branch)/update_dockerfiles"
-        taskSpec:
-          params:
-            - name: repo_name
-            - name: repo_owner
-            - name: source_branch
-            - name: target_branch
-          results:
-            - name: skip-open-pr
-              description: Flag that controls whether or not to open a PR
-              type: string
-          steps:
-            - name: update-dockerfiles
-              image: quay.io/redhat-pipeline-service/dependencies-update:$(params.source_branch)
-              imagePullPolicy: Always
-              workingDir: $(workspaces.source.path)
-              command:
-                - ./developer/images/dependencies-update/hack/bin/update.sh
-                - --commit_to
-                - "$(params.target_branch)"
-                - --task
-                - update_dockerfiles_base_images_sha
-                - --workspace_dir
-                - $(workspaces.source.path)
-            - name: is-pr-skipped
-              image: quay.io/redhat-pipeline-service/dependencies-update:$(params.source_branch)
-              imagePullPolicy: Always
-              env:
-                - name: GITHUB_TOKEN
-                  valueFrom:
-                    secretKeyRef:
-                      name: github
-                      key: token
-              workingDir: $(workspaces.source.path)
-              command:
-                - ./developer/images/dependencies-update/hack/bin/is-pr-skipped.sh
-                - --debug
-                - --name
-                - $(params.repo_name)
-                - --owner
-                - $(params.repo_owner)
-                - --target_branch
-                - $(params.target_branch)
-                - --result
-                - $(results.skip-open-pr.path)
-          workspaces:
-            - name: source
-      - name: open-pr-dockerfiles
-        when:
-          - input: "$(tasks.update-dockerfiles.results.skip-open-pr)"
-            operator: in
-            values: ["no"]
-        runAfter:
-          - update-dockerfiles
-        taskRef:
-          name: github-open-pr
-          kind: Task
-        params:
-          - name: REPO_FULL_NAME
-            value: "$(params.repo_owner)/$(params.repo_name)"
-          - name: BASE
-            value: $(params.source_branch)
-          - name: HEAD
-            value: robot/$(params.source_branch)/update_dockerfiles
-          - name: BODY
-            value: Generated by developer/images/dependencies-update/hack/bin/update.sh
-          - name: TITLE
-            value: Update Dockerfiles
-      - name: update-binaries
-        runAfter:
-          - open-pr-dockerfiles
-        workspaces:
-          - name: source
-            workspace: source
-        params:
-          - name: repo_name
-            value: $(params.repo_name)
-          - name: repo_owner
-            value: $(params.repo_owner)
-          - name: source_branch
-            value: $(params.source_branch)
-          - name: target_branch
-            value: "robot/$(params.source_branch)/update_binaries"
-        taskSpec:
-          params:
-            - name: repo_name
-            - name: repo_owner
-            - name: source_branch
-            - name: target_branch
-          results:
-            - name: skip-open-pr
-              description: Flag that controls whether or not to open a PR
-              type: string
-          steps:
-            - name: update-binaries
-              image: quay.io/redhat-pipeline-service/dependencies-update:$(params.source_branch)
-              imagePullPolicy: Always
-              workingDir: $(workspaces.source.path)
-              command:
-                - ./developer/images/dependencies-update/hack/bin/update.sh
-                - --commit_to
-                - "$(params.target_branch)"
-                - --task
-                - update_binaries
-                - --workspace_dir
-                - $(workspaces.source.path)
-            - name: is-pr-skipped
-              image: quay.io/redhat-pipeline-service/dependencies-update:$(params.source_branch)
-              imagePullPolicy: Always
-              env:
-                - name: GITHUB_TOKEN
-                  valueFrom:
-                    secretKeyRef:
-                      name: github
-                      key: token
-              workingDir: $(workspaces.source.path)
-              command:
-                - ./developer/images/dependencies-update/hack/bin/is-pr-skipped.sh
-                - --debug
-                - --name
-                - $(params.repo_name)
-                - --owner
-                - $(params.repo_owner)
-                - --target_branch
-                - $(params.target_branch)
-                - --result
-                - $(results.skip-open-pr.path)
-          workspaces:
-            - name: source
-      - name: open-pr-binaries
-        when:
-          - input: "$(tasks.update-binaries.results.skip-open-pr)"
-            operator: in
-            values: ["no"]
-        runAfter:
-          - update-binaries
-        taskRef:
-          name: github-open-pr
-          kind: Task
-        params:
-          - name: REPO_FULL_NAME
-            value: "$(params.repo_owner)/$(params.repo_name)"
-          - name: BASE
-            value: $(params.source_branch)
-          - name: HEAD
-            value: robot/$(params.source_branch)/update_binaries
-          - name: BODY
-            value: Generated by developer/images/dependencies-update/hack/bin/update.sh
-          - name: TITLE
-            value: Update binaries
   workspaces:
-    - name: source
+    - name: workdir
       volumeClaimTemplate:
         spec:
           accessModes:


### PR DESCRIPTION
* Use pipelineRef and taskRef
* Start work to make the task generic enough so it can be submitted to redhat-appstudio/build-definitions

Note that the Task is currently incomplete as it does not push the changes made by the script back to the repository.