### PR TITLE
add tekton chains grafana dashboard

### DIFF
--- a/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
+++ b/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
@@ -3618,6 +3618,193 @@
       "timeShift": null,
       "title": "Watcher Latency",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 179
+      },
+      "id": 79,
+      "panels": [],
+      "repeat": "datasource",
+      "repeatDirection": "h",
+      "title": "Tekton Chains",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 180
+      },
+      "id": 81,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "editorMode": "builder",
+          "expr": "rate(watcher_go_gc_cpu_fraction{app=\"tekton-chains-controller\"}[5m])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Tekton Chains CPU Fraction Use",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 180
+      },
+      "id": 83,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "editorMode": "builder",
+          "expr": "rate(watcher_workqueue_longest_running_processor_seconds_count{app=\"tekton-chains-controller\"}[5m])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Tekton Chains Workqueue Rate",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-observability-service.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-observability-service.yaml
@@ -4,9 +4,12 @@ kind: Service
 metadata:
   name: tekton-chains
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   labels:
-    app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-chains
+    app.kubernetes.io/component: metrics
+    app: tekton-chains-controller
 spec:
   ports:
     - name: metrics
@@ -14,4 +17,6 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    app: tekton-chains-controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-chains
+    app.kubernetes.io/component: controller

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-service-monitor.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-service-monitor.yaml
@@ -7,10 +7,22 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
+  jobLabel: "app.kubernetes.io/name"
   endpoints:
     - path: /metrics
       port: metrics
+      interval: 15s
       scheme: http
+      honorLabels: true
+  namespaceSelector:
+    matchNames:
+      - openshift-pipelines
   selector:
     matchLabels:
+      app.kubernetes.io/part-of: tekton-chains
+      app.kubernetes.io/component: metrics
       app: tekton-chains-controller
+  targetLabels:
+    - app
+    - app.kubernetes.io/component
+    - app.kubernetes.io/part-of

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
@@ -10,15 +10,3 @@ resources:
   - chains-service-monitor.yaml
   # Manully add ConfigMap and Service until PLNSRVCE-1359 is fixed
   - chains-observability-service.yaml
-
-## add a patch to add app label to the tekton chains deployment
-patches:
-  - target:
-      kind: Deployment
-      name: tekton-chains-controller
-      namespace: openshift-pipelines
-    patch: |-
-      - op: add
-        path: /metadata/labels
-        value:
-          app: tekton-chains-controller


### PR DESCRIPTION
## Changes

- fix tekton chains servicemonitor issue
- remove tekton chains patches
- add grafana dashboard with two metrics
- refer PLNSRVCE-1332

## Dashboard
![2023-08-29T16:13:52,147542736+05:30](https://github.com/openshift-pipelines/pipeline-service/assets/74113200/206724f2-2552-48b1-a1ef-b5ec5195f51e)

## Note

**Chains currently does not have any useful metrics**

Signed-off-by: Avinal Kumar <avinal@redhat.com>
