### PR TITLE
Remove refs to PaC namespace

### DIFF
--- a/developer/openshift/reset.sh
+++ b/developer/openshift/reset.sh
@@ -237,13 +237,6 @@ uninstall_operators_and_controllers(){
       kubectl delete operator "$gitops_operator"
     fi
 
-    printf "\n  Uninstalling PAC:\n"
-    kubectl delete -k "$GITOPS_DIR/pipelines-as-code" --ignore-not-found=true
-    pac_ns=$(kubectl get ns | grep -ie "pipelines-as-code" | cut -d " " -f 1)
-    if [[ -n "$pac_ns" ]]; then
-      kubectl delete ns "$pac_ns"
-    fi
-
     printf "\n  Uninstalling tekton-results:\n"
     kubectl delete -k "$GITOPS_DIR/tekton-results" --ignore-not-found=true
     tkn_results_ns=$(kubectl get ns | grep -ie "tekton-results" | cut -d " " -f 1)

--- a/operator/test/test.sh
+++ b/operator/test/test.sh
@@ -270,11 +270,6 @@ test_security() {
   echo "  - Check Pod Host Network openshift-pipelines: "
   check_host_network "openshift-pipelines"
 
-  echo "  - Check Pod Security pipelines-as-code: "
-  check_pod_security "pipelines-as-code"
-  echo "  - Check Pod Host Network pipelines-as-code: "
-  check_host_network "pipelines-as-code"
-
   echo "  - Check Pod Security tekton-results: "
   check_pod_security "tekton-results"
   echo "  - Check Pod Host Network tekton-results: "


### PR DESCRIPTION
With PaC being installed by the OSP operator, we no longer need the pipelines-as-code namespace. Here we cleanup references to that namespace from the reset and test scripts.