### PR TITLE
Fix podman image tag used in CI

### DIFF
--- a/developer/images/devenv/Dockerfile
+++ b/developer/images/devenv/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/podman/stable:v4.5.1
+FROM quay.io/podman/stable:v4.6
 RUN set -x \
     && mkdir ~/.kube \
     && mkdir -p /tmp/image-build \

--- a/operator/test/manifests/test/tekton-chains/simple-copy-pipeline.yaml
+++ b/operator/test/manifests/test/tekton-chains/simple-copy-pipeline.yaml
@@ -32,7 +32,7 @@ spec:
             description: Reference of the image skopeo will push.
           - name: SKOPEO_IMAGE
             description: The location of the skopeo image.
-            default: quay.io/skopeo/stable:v1.9.0
+            default: quay.io/skopeo/stable:v1.13
           - name: srcTLSverify
             description: Verify the TLS on the src registry endpoint
             type: string


### PR DESCRIPTION
We were using the v4.5.1 tag and it's been replaced by v4.6.1. Those both are floating tags and not static ones, so it does not make much difference if we start using a bit more generic one v4.6 while still preserving the versions of the extra rpms installed. Same happened with the skopeo image, replaced with the new one.