### PR TITLE
allow ingress annotation overwrite

### DIFF
--- a/developer/openshift/dev_setup.sh
+++ b/developer/openshift/dev_setup.sh
@@ -158,7 +158,7 @@ cluster_setup() {
 
   # By default HTTP2 is not enabled in test openshift clusters
   echo "- Enabling HTTP2 for ingress" | indent 2
-  oc annotate ingresses.config/cluster ingress.operator.openshift.io/default-enable-http2=true | indent 6
+  oc annotate ingresses.config/cluster ingress.operator.openshift.io/default-enable-http2=true --overwrite=true| indent 6
 }
 
 install_openshift_gitops() {


### PR DESCRIPTION
Re-running the dev_setup.sh script results into an error:
    ```
    error: --overwrite is false but found the following declared
    annotation(s): 'ingress.operator.openshift.io/default-enable-http2'
    already has a value (true)
    ```
This PR aims to fix this error.