### PR TITLE
Add errexit,nounset,pipefail to chains-secrets-config job

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
@@ -61,37 +61,43 @@ spec:
             - /bin/bash
             - -c
             - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+
+              namespace="openshift-pipelines"
+              secret="signing-secrets"
+
               cd /tmp
-              # Try to handle that nicely. The object is expected to always exist so check the data.
-              SIG_KEY_DATA=$(kubectl get secret signing-secrets -n openshift-pipelines -o jsonpath='{.data}')
-              if [[ -n $SIG_KEY_DATA ]]; then
+
+              if [ "$(kubectl get secret "$secret" -n "$namespace" -o jsonpath='{.data}' --ignore-not-found --allow-missing-template-keys)" != "" ]; then
                 echo "Signing secret exists and is non-empty."
               else
                 # Delete secret/signing-secrets if already exists since by default cosign creates immutable secrets
-                kubectl delete secrets -n openshift-pipelines signing-secrets --ignore-not-found=true
+                kubectl delete secrets "$secret" -n "$namespace" --ignore-not-found=true
 
                 # To make this run conveniently without user input let's create a random password
-                RANDOM_PASS=$( head -c 12 /dev/urandom | base64 )
+                RANDOM_PASS=$( openssl rand -base64 30 )
 
                 # Generate the key pair secret directly in the cluster.
                 # The secret should be created as immutable.
-                echo "Generating k8s secret/signing-secrets with key-pair"
-                env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair k8s://openshift-pipelines/signing-secrets
+                echo "Generating k8s secret/$secret in $namespace with key-pair"
+                env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair "k8s://$namespace/$secret"
               fi
 
               # If the secret is not marked as immutable, make it so.
-              if [ "$(kubectl get secret signing-secrets -n openshift-pipelines -o jsonpath='{.immutable}')" != "true" ]; then
+              if [ "$(kubectl get secret "$secret" -n "$namespace" -o jsonpath='{.immutable}')" != "true" ]; then
                 echo "Making secret immutable"
-                kubectl get secret signing-secrets -n openshift-pipelines -o yaml \
-                | yq eval '.immutable = true' - \
+                kubectl patch secret "$secret" -n "$namespace" --dry-run=client -o yaml \
+                  --patch='{"immutable": true}' \
                 | kubectl apply -f -
               fi
 
               echo "Generating/updating the secret with the public key"
               kubectl create secret generic public-key \
-                --namespace openshift-pipelines \
+                --namespace "$namespace" \
                 --from-literal=cosign.pub="$(
-                  cosign public-key --key k8s://openshift-pipelines/signing-secrets
+                  cosign public-key --key "k8s://$namespace/$secret"
                 )" \
                 --dry-run=client \
                 -o yaml | kubectl apply -f -


### PR DESCRIPTION
This will ensure that any failure to setup the secret is properly reported in the job status.