### PR TITLE
[DNM] fix chains signing-secrets public-key access

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
@@ -25,6 +25,7 @@ rules:
       - get
       - update
       - patch
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -65,16 +66,20 @@ spec:
               # Try to handle that nicely. The object is expected to always exist so check the data.
               SIG_KEY_DATA=$(kubectl get secret signing-secrets -n openshift-pipelines -o jsonpath='{.data}')
               if [[ -n $SIG_KEY_DATA ]]; then
-                echo "Signing secret exists."
+                echo "Signing secret exists and is non-empty."
               else
+                # Delete secret/signing-secrets if already exists since by default cosign creates immutable secrets
+                kubectl delete secrets -n openshift-pipelines signing-secrets --ignore-not-found=true
+
                 # To make this run conveniently without user input let's create a random password
                 RANDOM_PASS=$( head -c 12 /dev/urandom | base64 )
 
                 # Generate the key pair secret directly in the cluster.
+                echo "Generating k8s secret/signing-secrets with key-pair"
                 env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair k8s://openshift-pipelines/signing-secrets
               fi
 
-              # Generate/update the secret with the public key
+              echo "Generating/updating the secret with the public key"
               kubectl create secret generic public-key \
                 --namespace openshift-pipelines \
                 --from-literal=cosign.pub="$(

--- a/operator/test/manifests/test/tekton-chains/public-key.yaml
+++ b/operator/test/manifests/test/tekton-chains/public-key.yaml
@@ -19,5 +19,10 @@ spec:
                 set -o pipefail
                 set -x
                 PUBLIC_KEY=$(oc get secret public-key -n openshift-pipelines -o jsonpath='{.data.cosign\.pub}')
+                if [[ -z "$PUBLIC_KEY" ]]; then
+                  echo "[ERROR] Public key is empty."
+                  exit 1
+                fi
+                echo "Public key exists."
                 echo "$PUBLIC_KEY" | base64 -d
   serviceAccountName: chains-test

--- a/operator/test/test.sh
+++ b/operator/test/test.sh
@@ -205,6 +205,12 @@ test_chains() {
   echo -n "  - Public key: "
   pipeline_name=$(kubectl create -f "$SCRIPT_DIR/manifests/test/tekton-chains/public-key.yaml" -n "$NAMESPACE" | cut -d' ' -f1)
   wait_for_pipeline "$pipeline_name" "$NAMESPACE"
+
+#  debug
+  exact_pr_name=$(echo "$pipeline_name" | cut -d'/' -f2)
+  tkn pr logs -n "$NAMESPACE" "$exact_pr_name"
+  kubectl describe "$pipeline_name" -n "$NAMESPACE"
+
   if [ "$(kubectl get "$pipeline_name" -n "$NAMESPACE" \
     -o 'jsonpath={.status.conditions[0].reason}')" = "Succeeded" ]; then
     echo "OK"


### PR DESCRIPTION
* Cosign by default creates immutable secrets, so we need delete
    permissions in openshift-pipelines namespace over secrets
    https://github.com/sigstore/cosign/blob/main/pkg/cosign/kubernetes/secret.go#L119C5-L119C14
* additional check to make sure public key is not empty.