### PR TITLE
Make the tekton-chains signing-secrets immutable

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
@@ -55,14 +55,13 @@ spec:
     spec:
       containers:
         - name: chains-secret-generation
-          image: quay.io/redhat-appstudio/appstudio-utils:eb94f28fe2d7c182f15e659d0fdb66f87b0b3b6b
+          image: quay.io/redhat-appstudio/appstudio-utils:dbbdd82734232e6289e8fbae5b4c858481a7c057
           imagePullPolicy: Always
           command:
             - /bin/bash
             - -c
             - |
               cd /tmp
-              # Once the key-pair has been set it's marked as immutable so it can't be updated.
               # Try to handle that nicely. The object is expected to always exist so check the data.
               SIG_KEY_DATA=$(kubectl get secret signing-secrets -n openshift-pipelines -o jsonpath='{.data}')
               if [[ -n $SIG_KEY_DATA ]]; then
@@ -75,8 +74,17 @@ spec:
                 RANDOM_PASS=$( head -c 12 /dev/urandom | base64 )
 
                 # Generate the key pair secret directly in the cluster.
+                # The secret should be created as immutable.
                 echo "Generating k8s secret/signing-secrets with key-pair"
                 env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair k8s://openshift-pipelines/signing-secrets
+              fi
+
+              # If the secret is not marked as immutable, make it so.
+              if [ "$(kubectl get secret signing-secrets -n openshift-pipelines -o jsonpath='{.immutable}')" != "true" ]; then
+                echo "Making secret immutable"
+                kubectl get secret signing-secrets -n openshift-pipelines -o yaml \
+                | yq eval '.immutable = true' - \
+                | kubectl apply -f -
               fi
 
               echo "Generating/updating the secret with the public key"


### PR DESCRIPTION
@gabemontero @ramessesii2 I've noticed that in our environments the secrets are not immutable. That's because they were created through a different process than we use know.

I've modified the job so it transforms mutable secrets into immutable secrets, which will help with configuration drift.

This PR should be merged after #776.