### PR TITLE
DO-NOT-MERGE test OSP nightly deployment in CI

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - allow-argocd-to-manage.yaml
   - allow-argocd-to-manage-jobs.yaml
   - appstudio-pipelines-scc.yaml
+  - osp-nightly-catalog-source.yaml
   - openshift-operator.yaml
   - tekton-config.yaml
   - config-logging.yaml

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/openshift-operator.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/openshift-operator.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
-  channel: pipelines-1.13
+  channel: latest
   name: openshift-pipelines-operator-rh
-  source: redhat-operators
+  source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/osp-nightly-catalog-source.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/osp-nightly-catalog-source.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: custom-operators
+  namespace: openshift-marketplace
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  sourceType: grpc
+  image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-operator-bundle-container-index:v4.14-v5.0-28
+  displayName: custom-operators
+  updateStrategy:
+    registryPoll:
+      interval: 30m


### PR DESCRIPTION
This is to test the OSP nightly deployment in the Pipeline Service CI.