### PR TITLE
PLNSRVCE-1469: print 'No data' when the scheduling alert query has no data

### DIFF
--- a/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
+++ b/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
@@ -104,6 +104,7 @@
           "mappings": [],
           "max": 1,
           "min": 0,
+          "noValue": "No data",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -161,7 +162,7 @@
           "refId": "pipelinerun-success"
         }
       ],
-      "title": "Scheduling",
+      "title": "Tekton Scheduling Overhead",
       "transformations": [],
       "type": "stat"
     },


### PR DESCRIPTION
by the way now that I know what to do here @openshift-pipelines/pipelines-service I found other examples of this setting in our dashboard file here