### PR TITLE
Fix kube-linter issues

### DIFF
--- a/developer/openshift/gitops/argocd/pipeline-service/tekton-results/minio-create-bucket.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service/tekton-results/minio-create-bucket.yaml
@@ -56,3 +56,11 @@ spec:
             - name: ca-s3
               mountPath: /etc/ssl/certs/s3-cert.crt
               subPath: s3-cert.crt
+            - name: tmp-mc-volume
+              mountPath: /tmp
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+      volumes:
+        - name: tmp-mc-volume
+          emptyDir: {}

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
@@ -30,4 +30,7 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "500m"
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
       restartPolicy: Always

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
@@ -101,6 +101,9 @@ spec:
                 )" \
                 --dry-run=client \
                 -o yaml | kubectl apply -f -
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       terminationGracePeriodSeconds: 30

--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-kube-rbac-proxy.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-kube-rbac-proxy.yaml
@@ -17,6 +17,8 @@ spec:
             - "--v=6"
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
             capabilities:

--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-migrator-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-migrator-config.yaml
@@ -34,3 +34,5 @@ spec:
                 secretKeyRef:
                   name: tekton-results-database
                   key: db.name
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-s3-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-s3-config.yaml
@@ -43,3 +43,5 @@ spec:
                 secretKeyRef:
                   key: endpoint
                   name: tekton-results-s3
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
@@ -19,3 +19,5 @@ spec:
               "-auth_mode",
               "token",
             ]
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-kube-rbac-proxy.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-kube-rbac-proxy.yaml
@@ -17,6 +17,8 @@ spec:
             - "--v=6"
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
             capabilities:


### PR DESCRIPTION
* run containers as non root
* run containers with read only root file system

The 'mc' init container is using the /tmp folder so for that container, mount an empty dir volume to /tmp to be able to set root file system readonly while being able to write to /tmp.

PLNSRVCE-1476