### PR TITLE
Fix a minor error of devenv image

### DIFF
--- a/developer/images/devenv/Dockerfile
+++ b/developer/images/devenv/Dockerfile
@@ -9,7 +9,7 @@ RUN set -x \
         openssl-3.0.9 \
         procps-ng-3.3.17 \
         # python3-devl is needed when installing checkov's dependencies
-        python3-devel-3.11.5 \
+        python3-devel-3.11.6 \
         rsync-3.2.7 \
         unzip-6.0 \
         which-2.21 \


### PR DESCRIPTION
It reported error `Error: Unable to find a match: python3-devel-3.11.5` when building devenv image. It needs to install `python3-devel-3.11.6` as replacement.