### PR TITLE
Set cpu/memory requests/limits for tekton-results-watcher/watcher

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
@@ -20,5 +20,12 @@ spec:
               "-completed_run_grace_period",
               "10m",
             ]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 2Gi
           securityContext:
             readOnlyRootFilesystem: true


### PR DESCRIPTION
This container does not take much resources on low traffic instances such as a dev environment:
```
oc adm top pod tekton-results-watcher-6594cbf977-xwf6c --containers
POD                                       NAME      CPU(cores)   MEMORY(bytes)
tekton-results-watcher-6594cbf977-xwf6c   watcher   0m           37Mi
```

It does required more resources on production environment:
```
oc adm top pod tekton-results-watcher-6fb969985-bh7qm --containers
POD                                      NAME       CPU(cores)   MEMORY(bytes)
tekton-results-watcher-6fb969985-bh7qm   watcher    111m         1145Mi
```

Set cpu/memory requests quite low(100m/64Mi) to accommodate low traffic
environment and set limits high enough(250m/2Gi) for high traffic
environments.

PLNSRVCE-1476