### PR TITLE
Set cpu/memory requests/limits for tekton-results-api/api

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-s3-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-s3-config.yaml
@@ -43,5 +43,12 @@ spec:
                 secretKeyRef:
                   key: endpoint
                   name: tekton-results-s3
+          resources:
+            requests:
+              cpu: 5m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 512Mi
           securityContext:
             readOnlyRootFilesystem: true


### PR DESCRIPTION
This container is similar resources consumption wise on low and high traffic instances at rest:
```
oc adm top pod tekton-results-api-6bcb5d967-wspvm --containers
POD                                  NAME    CPU(cores)   MEMORY(bytes)
tekton-results-api-6bcb5d967-wspvm   api     1m           39Mi
```
```
oc adm top pod tekton-results-api-7bff76858f-thgrf --containers
POD                                   NAME   CPU(cores)   MEMORY(bytes)
tekton-results-api-7bff76858f-thgrf   api    2m           64Mi
```
It does has peak around 340Mi on high traffic instances.

PLNSRVCE-1476