### PR TITLE
Set Set cpu/memory requests/limits for tekton-results-api init containers

### DIFF
--- a/developer/openshift/gitops/argocd/pipeline-service/tekton-results/minio-create-bucket.yaml
+++ b/developer/openshift/gitops/argocd/pipeline-service/tekton-results/minio-create-bucket.yaml
@@ -58,6 +58,13 @@ spec:
               subPath: s3-cert.crt
             - name: tmp-mc-volume
               mountPath: /tmp
+          resources:
+            requests:
+              cpu: 5m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true

--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-migrator-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-migrator-config.yaml
@@ -34,5 +34,12 @@ spec:
                 secretKeyRef:
                   name: tekton-results-database
                   key: db.name
+          resources:
+            requests:
+              cpu: 5m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true


### PR DESCRIPTION
Init containers are harder to figure out the required resources as they do not run long enough to have metrics collected. Both container worked with 5m/32Mi in a dev environment. Put the limits higher to make sure they works in production environment even though the nature of the work done by both should not differ much from dev to production environment.

PLNSRVCE-1476