### PR TITLE
Fix TektonConfig

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -10,6 +10,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
 spec:
+  targetNamespace: openshift-pipelines
+  profile: all
   params:
     - name: createRbacResource
       value: "false"


### PR DESCRIPTION
Restore a setting that was mistakenly removed with commit b2626be4fc649b5184b8bf3e661bbc46319c884b
which break the deployment of the application