### PR TITLE
Enable OSP pruner

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -48,4 +48,11 @@ spec:
       kube-api-qps: 50
       kube-api-burst: 50
   pruner:
-    disabled: true
+    # Some resources have an ownerReference which prevents them from being deleted
+    # by tekton-results.
+    # Until this is fixed, the pruner will handle those resources.
+    # disabled: true
+    keep: 10
+    resources:
+      - pipelinerun
+    schedule: 0/2 * * * *


### PR DESCRIPTION
The tekton result pruner is not deleting all PLRs after completion because of a safeguard mechanism when PLR have an ownerRef.

This change restores the pruner to handle those resources.