### PR TITLE
fix missing millisecond to second conversion in grafana dashboard execute overhead query

### DIFF
--- a/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
+++ b/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
@@ -212,7 +212,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "(\n  (sum(pipelinerun_gap_between_taskruns_milliseconds_sum{status='succeded'})/1000 - sum(pipelinerun_gap_between_taskruns_milliseconds_sum{status='succeded'} offset 30m)/1000)\n  / \n  (sum(pipelinerun_gap_between_taskruns_milliseconds_count{status='succeded'}) - sum(pipelinerun_gap_between_taskruns_milliseconds_count{status='succeded'} offset 30m))\n) \n/ \n(\n  (sum(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'}) - sum(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'} offset 30m))\n  / \n  (sum(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}) - sum(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}offset 30m))\n)",
+          "expr": "(\n  (sum(pipelinerun_gap_between_taskruns_milliseconds_sum{status='succeded'})/1000 - sum(pipelinerun_gap_between_taskruns_milliseconds_sum{status='succeded'} offset 30m)/1000)\n  / \n  (sum(pipelinerun_gap_between_taskruns_milliseconds_count{status='succeded'})/1000 - sum(pipelinerun_gap_between_taskruns_milliseconds_count{status='succeded'} offset 30m)/1000)\n) \n/ \n(\n  (sum(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'}) - sum(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'} offset 30m))\n  / \n  (sum(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}) - sum(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}offset 30m))\n)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
Noticed this while I was working on the gitlab app-sre SLO/SLI docs 