### PR TITLE
optimize alert query; revert incorrect millisecond to second conversion fix

### DIFF
--- a/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
+++ b/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
@@ -146,7 +146,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": " (sum(pipelinerun_duration_scheduled_seconds_sum) - sum(pipelinerun_duration_scheduled_seconds_sum offset 30m)) / (sum(pipelinerun_duration_scheduled_seconds_count) - sum(pipelinerun_duration_scheduled_seconds_count offset 30m)) / (sum(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'}) - sum(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'} offset 30m)) / (sum(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}) - sum(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'} offset 30m))",
+          "expr": "(sum(sum_over_time(pipelinerun_duration_scheduled_seconds_sum[30m])) / sum(sum_over_time(pipelinerun_duration_scheduled_seconds_count[30m]))) / (sum(sum_over_time(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'}[30m])) / sum(sum_over_time(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}[30m])))",
           "format": "table",
           "hide": false,
           "instant": false,
@@ -212,7 +212,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "(\n  (sum(pipelinerun_gap_between_taskruns_milliseconds_sum{status='succeded'})/1000 - sum(pipelinerun_gap_between_taskruns_milliseconds_sum{status='succeded'} offset 30m)/1000)\n  / \n  (sum(pipelinerun_gap_between_taskruns_milliseconds_count{status='succeded'})/1000 - sum(pipelinerun_gap_between_taskruns_milliseconds_count{status='succeded'} offset 30m)/1000)\n) \n/ \n(\n  (sum(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'}) - sum(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'} offset 30m))\n  / \n  (sum(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}) - sum(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}offset 30m))\n)",
+          "expr": "(sum(sum_over_time(pipelinerun_gap_between_taskruns_milliseconds_sum{status='succeded'}[30m])/1000) / sum(sum_over_time(pipelinerun_gap_between_taskruns_milliseconds_count{status='succeded'}[30m]))) / (sum(sum_over_time(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'}[30m])) / sum(sum_over_time(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}[30m])))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
During unsuccessful attempts to get our alert queries running on the app-sre grafana dashboard, I did come up with a simpler query which reaches the same basic effect of only using the last 30 minutes of data available.  This change will also work better with the use of range seen in other successful app-sre dashboard queries.
Also, I realized an earlier change by me  to divide our milliscecond metric's _count by 1000 was incorrect.  Only the _sum has actual millisecond based observations that need to be converted (as was originally done).

The PR where I incorrectly changed what @ramessesii2 had for converting milliseconds to seconds was https://github.com/openshift-pipelines/pipeline-service/pull/835

Here is a screen shot of how the new queries look in RHTAP red-hat prod:

![optimized-queries](https://github.com/openshift-pipelines/pipeline-service/assets/3594868/a8ccd691-65c5-481b-9c8e-1448cd495175)
