### PR TITLE
Update checkov configuration

### DIFF
--- a/ci/images/static-checks/content/config/checkov.yaml
+++ b/ci/images/static-checks/content/config/checkov.yaml
@@ -52,7 +52,6 @@ skip-check:
   - CKV_K8S_155
   - CKV_K8S_157
   - CKV2_K8S_6 # use NetworkPolicy like what registration-service and integration-service employ are untenable for tekton controllers
-skip-fixes: true
 soft-fail: false
 skip-path:
   - developer


### PR DESCRIPTION
The --skip-fixes flag has been deprecated in v3.x.