### PR TITLE
update scheduled alert panel to only use successful pipelineruns with scheduled metric

### DIFF
--- a/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
+++ b/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
@@ -146,7 +146,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "(sum(sum_over_time(pipelinerun_duration_scheduled_seconds_sum[30m])) / sum(sum_over_time(pipelinerun_duration_scheduled_seconds_count[30m]))) / (sum(sum_over_time(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'}[30m])) / sum(sum_over_time(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}[30m])))",
+          "expr": "(sum(sum_over_time(pipelinerun_duration_scheduled_seconds_sum{status='succeded'}[30m])) / sum(sum_over_time(pipelinerun_duration_scheduled_seconds_count{status='succeded'}[30m]))) / (sum(sum_over_time(tekton_pipelines_controller_pipelinerun_duration_seconds_sum{status='success'}[30m])) / sum(sum_over_time(tekton_pipelines_controller_pipelinerun_duration_seconds_count{status='success'}[30m])))",
           "format": "table",
           "hide": false,
           "instant": false,


### PR DESCRIPTION
During some recent monitoring of the alert panels in stage and prod, a rash of pipelinerun errors lead to some abnormally high levels for the schedule overhead alert as compared to the execution overhead alert.  This was the motivation to add the status label to the schedule metric like we already have on the other ones.  This change now leverages that label in the grafana dashboard.