### PR TITLE
fix threshold color for 2 alert panels

### DIFF
--- a/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
+++ b/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
@@ -103,7 +103,7 @@
           "min": 0,
           "noValue": "No data",
           "thresholds": {
-            "mode": "absolute",
+            "mode": "percentage",
             "steps": [
               {
                 "color": "green",
@@ -171,7 +171,7 @@
           "min": 0,
           "noValue": "No data",
           "thresholds": {
-            "mode": "absolute",
+            "mode": "percentage",
             "steps": [
               {
                 "color": "green",


### PR DESCRIPTION
Figured out via temporary edits to the appstudio dashboards that our alert panels the threshold switch in color from green to red will only occur if the mode is percentage vs. absolute