### PR TITLE
bump CI ocp versions to make hosted control plane happy

### DIFF
--- a/.tekton/tasks/deploy-cluster.yaml
+++ b/.tekton/tasks/deploy-cluster.yaml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: ocp_version
       description: ocp cluster version that you want to provision
-      default: "4.12.36"
+      default: "4.12.41"
     - name: region
       description: ocp cluster region where you want to provision
       default: "us-east-1"

--- a/.tekton/test-pipeline-service-deployment-ocp-412.yaml
+++ b/.tekton/test-pipeline-service-deployment-ocp-412.yaml
@@ -20,7 +20,7 @@ spec:
     name: test-pipeline-service-deployment
   params:
     - name: ocp_version
-      value: "4.12.36"
+      value: "4.12.41"
     - name: repo_url
       value: "{{ repo_url }}"
     - name: revision

--- a/.tekton/test-pipeline-service-deployment-ocp-413.yaml
+++ b/.tekton/test-pipeline-service-deployment-ocp-413.yaml
@@ -20,7 +20,7 @@ spec:
     name: test-pipeline-service-deployment
   params:
     - name: ocp_version
-      value: "4.13.13"
+      value: "4.13.19"
     - name: repo_url
       value: "{{ repo_url }}"
     - name: revision

--- a/.tekton/test-rhtap-e2e.yaml
+++ b/.tekton/test-rhtap-e2e.yaml
@@ -18,7 +18,7 @@ spec:
     name: test-rhtap-e2e
   params:
     - name: ocp_version
-      value: "4.12.36"
+      value: "4.12.41"
     - name: repo_url
       value: "{{ repo_url }}"
     - name: revision


### PR DESCRIPTION
ERR: Failed to create cluster: Version '4.13.13' is below minimum supported for Hosted Control Plane  and ERR: Failed to create cluster: Version '4.12.36' is below minimum supported for Hosted Control Plane