### PR TITLE
Bump github action/checkout version

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get the short sha
         id: vars

--- a/.github/workflows/individual-image-scanner-quay.yaml
+++ b/.github/workflows/individual-image-scanner-quay.yaml
@@ -30,7 +30,7 @@ jobs:
       static-checks-output: ${{ steps.static-checks-scan.outputs.VULNERABILITIES_EXIST }}
       vulnerability-scan-output: ${{ steps.vulnerability-scan.outputs.VULNERABILITIES_EXIST }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v2
         id: filter
@@ -132,7 +132,6 @@ jobs:
     needs: scans
     if: always()
     steps:
-
       - name: Check ci-runner results
         id: check-ci-runner-results
         if: always()

--- a/.github/workflows/periodic-scanner-quay.yaml
+++ b/.github/workflows/periodic-scanner-quay.yaml
@@ -13,7 +13,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Fetch results
         id: fetch-results


### PR DESCRIPTION
This should get rid of the 'actions uses node12 which is deprecated' warning.