### PR TITLE
add empty args for safer patching in infra-deployments

### DIFF
--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       containers:
         - name: pipeline-metrics-exporter
           image: quay.io/redhat-appstudio/pipeline-service-exporter:placeholder
+          args: []
           ports:
             - containerPort: 9117
               name: metrics


### PR DESCRIPTION
This way, we can just append args in infra-deployments if we want to add new ones, but conversely we will not replace any future args we add in pipeline-service