### PR TITLE
build the kustomize output to Infra-deployment deploy file

### DIFF
--- a/.tekton/open-infra-deployment-pr.yaml
+++ b/.tekton/open-infra-deployment-pr.yaml
@@ -18,6 +18,8 @@ spec:
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/development/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/staging/base/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
+        kustomize build components/pipeline-service/staging/stone-stg-m01/resources/ > components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+        kustomize build components/pipeline-service/staging/stone-stg-rh01/resources/ > components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
     - name: slack-webhook-notification-team
       value: pipeline
   pipelineSpec:
@@ -39,6 +41,8 @@ spec:
             value: $(params.git-url)
           - name: REVISION
             value: $(params.revision)
+          - name: SCRIPT_IMAGE
+            value: "http://quay.io/devtools_gitops/test_image:4.0.5"
           - name: SCRIPT
             value: $(params.infra-deployment-update-script)
         taskRef:


### PR DESCRIPTION
The pipeline-service application is now updated via deploy file after pr: https://github.com/redhat-appstudio/infra-deployments/pull/2383

So adding the kustomize output in the infra-deployment-update-script so that the bot also update the deploy file for staging folder of pipeline-service