### PR TITLE
Disable 'check_owner' for Tekton Result watcher

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
@@ -17,6 +17,8 @@ spec:
               "tekton-results-api-service.tekton-results.svc.cluster.local:8080",
               "-auth_mode",
               "token",
+              "-check_owner",
+              "false",
               "-completed_run_grace_period",
               "10m",
             ]


### PR DESCRIPTION
This will enable the clean up of all PipelineRuns, including those having ownerReferences set to RHTAP resources.

Once the flag has been confirmed to work successfully, the default Pipelines pruner can be removed.

rh-pre-commit.version: 2.0.3
rh-pre-commit.check-secrets: ENABLED