### PR TITLE
Add missing staging path file for deploy kustomize output

### DIFF
--- a/.tekton/open-infra-deployment-pr.yaml
+++ b/.tekton/open-infra-deployment-pr.yaml
@@ -20,6 +20,7 @@ spec:
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
         kustomize build components/pipeline-service/staging/stone-stg-m01/resources/ > components/pipeline-service/staging/stone-stg-m01/deploy.yaml
         kustomize build components/pipeline-service/staging/stone-stg-rh01/resources/ > components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+        kustomize build components/pipeline-service/staging/stone-stage-p01/resources/ > components/pipeline-service/staging/stone-stage-p01/deploy.yaml
     - name: slack-webhook-notification-team
       value: pipeline
   pipelineSpec:


### PR DESCRIPTION
adding the kustomize output in the infra-deployment-update-script for missing staging/stone-stage-p01 path, so that the bot also update the deploy file for staging folder of pipeline-service