### PR TITLE
Ignore kube-linter dangling service issue for tekton-chains

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-observability-service.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-observability-service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-pipelines
   annotations:
     argocd.argoproj.io/sync-wave: "0"
+    ignore-check.kube-linter.io/dangling-service: This service is not dangling, it exposes metric for an OSP deployment
   labels:
     app.kubernetes.io/part-of: tekton-chains
     app.kubernetes.io/component: metrics


### PR DESCRIPTION
This service is required by pipeline-service so this is why it is defined here rather than in OSP. Ignore the kube-linter issue as this is not a dangling service, the pod selector does match an existing deployment.

PLNSRVCE-1476