### PR TITLE
Fix container argument syntax

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
@@ -17,8 +17,7 @@ spec:
               "tekton-results-api-service.tekton-results.svc.cluster.local:8080",
               "-auth_mode",
               "token",
-              "-check_owner",
-              "false",
+              "-check_owner=false",
               "-completed_run_grace_period",
               "10m",
             ]


### PR DESCRIPTION
Not sure how command line binary arguments are interpreted, but this seems to work. 