### PR TITLE
Disable OSP pruner

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -48,11 +48,4 @@ spec:
       kube-api-qps: 50
       kube-api-burst: 50
   pruner:
-    # Some resources have an ownerReference which prevents them from being deleted
-    # by tekton-results.
-    # Until this is fixed, the pruner will handle those resources.
-    # disabled: true
-    keep: 10
-    resources:
-      - pipelinerun
-    schedule: 0/2 * * * *
+    disabled: true


### PR DESCRIPTION
Tekton Results is now fully in charge of the deletion of pipelineruns

rh-pre-commit.version: 2.0.3
rh-pre-commit.check-secrets: ENABLED