### PR TITLE
Disabling check_owner because of a major bug

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
@@ -17,7 +17,7 @@ spec:
               "tekton-results-api-service.tekton-results.svc.cluster.local:8080",
               "-auth_mode",
               "token",
-              "-check_owner=false",
+              # "-check_owner=false",
               "-completed_run_grace_period",
               "10m",
             ]


### PR DESCRIPTION
A bug in Tekton Results needs to be fixed before we can activate the feature.

rh-pre-commit.version: 2.0.3
rh-pre-commit.check-secrets: ENABLED