### PR TITLE
fix sched/exec overhead thresholds for going red

### DIFF
--- a/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
+++ b/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
@@ -111,7 +111,7 @@
               },
               {
                 "color": "red",
-                "value": 3
+                "value": 5
               }
             ]
           },
@@ -179,7 +179,7 @@
               },
               {
                 "color": "red",
-                "value": 3
+                "value": 5
               }
             ]
           },


### PR DESCRIPTION
A while back we went from a 3% threshold to 5% threshold for the schedule and execution overheads; the app-sre grafana panels reflect this but our pipeline-service panels do not; this change fixes that