### PR TITLE
Increase memory request for tekton results API server

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-s3-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-s3-config.yaml
@@ -45,7 +45,7 @@ spec:
           resources:
             requests:
               cpu: 5m
-              memory: 32Mi
+              memory: 128Mi
             limits:
               cpu: 100m
               memory: 512Mi


### PR DESCRIPTION
Tekton results API server memory averages to 100Mi, hence increasing the request to 128Mi.

Data from Prod for last 7days.

<img width="815" alt="image" src="https://github.com/openshift-pipelines/pipeline-service/assets/2537717/3e147e3c-f871-41c3-8666-cb02345b9fee">
