### PR TITLE
PLNSRVCE-1525: expose controller HA fields for possible gitops override

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -44,6 +44,9 @@ spec:
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
     performance:
+      disable-ha: false
+      buckets: 1
+      replicas: 1
       threads-per-controller: 32
       kube-api-qps: 50
       kube-api-burst: 50


### PR DESCRIPTION
We'll maintain the default of 1 replica for the controller out of the gate in pipeline service

We'll overload for Konflux in infra-deployments once our related sanity check story around ensuring no negative performance of cluster capacity impacts have occurred when we separately enable multiple replicas in staging.

@openshift-pipelines/pipelines-service FYI