### PR TITLE
Skip downgrade test for OSP nightly builds changes

### DIFF
--- a/.github/workflows/update-osp-nightly.yaml
+++ b/.github/workflows/update-osp-nightly.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: "[new-osp-nightly-build] automated change"
+          # the title is used as conditional for some pipeline tasks, update accordingly
           title: "[DO-NOT-MERGE] Automated change to update OSP nightly"
           body: |
             Automated change by [update-osp-nightly]

--- a/.tekton/pipeline-service-upgrade-test-ocp-414.yaml
+++ b/.tekton/pipeline-service-upgrade-test-ocp-414.yaml
@@ -25,6 +25,8 @@ spec:
       value: "{{ revision }}"
     - name: target_branch
       value: "{{ target_branch }}"
+    - name: pr_title
+      value: "{{ body.pull_request.title }}"
   timeouts:
     pipeline: "1h30m0s"
   workspaces:

--- a/.tekton/pipeline/test-pipeline-service-upgrade.yaml
+++ b/.tekton/pipeline/test-pipeline-service-upgrade.yaml
@@ -8,6 +8,7 @@ spec:
     - name: repo_url
     - name: revision
     - name: target_branch
+    - name: pr_title
   timeouts:
     finally: "0h30m0s"
   workspaces:
@@ -110,6 +111,10 @@ spec:
     - name: downgrade-pipeline-service
       taskRef:
         name: deploy-pipeline-service
+      when:
+        - input: "$(params.pr_title)"
+          operator: notin
+          values: ["[DO-NOT-MERGE] Automated change to update OSP nightly"]
       runAfter:
         - "test-upgrade"
       workspaces:
@@ -125,6 +130,10 @@ spec:
     - name: test-downgrade
       taskRef:
         name: test-pipeline-service
+      when:
+        - input: "$(params.pr_title)"
+          operator: notin
+          values: ["[DO-NOT-MERGE] Automated change to update OSP nightly"]
       runAfter:
         - "downgrade-pipeline-service"
       params:


### PR DESCRIPTION
The nightly builds do not support downgrade. To revert to a previous version, a new version must be created revering the changes from the current one. In that case testing downgrade does not make sense.