### PR TITLE
Create namespaces before external secrets

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - chains-observability-service.yaml
   - chains-public-key-viewer.yaml
   - chains-secrets-config.yaml
+  - namespace.yaml

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/namespace.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/namespace.yaml
@@ -1,10 +1,10 @@
+# Solves https://issues.redhat.com/browse/PLNSRVCE-1620
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: tekton-results
+  name: openshift-pipelines
   labels:
     argocd.argoproj.io/managed-by: openshift-gitops
   annotations:
-    # Solves https://issues.redhat.com/browse/PLNSRVCE-1620
     argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
ExternalSecrets are creates at sync-wave "-1" and they are required for services like Tekton Results and OSP. But for the secrets to be created, the namespace should exist in advance. Here we create the namespace before the secret. It does not affect the deployment of the OSP operator, it ignores the fact the namespace it tries to create already exist.