### PR TITLE
PLNSRVCE-1585: exporter needs patch permissions

### DIFF
--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrole.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrole.yaml
@@ -19,7 +19,7 @@ rules:
 
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns", "taskruns"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "patch"]
 
   - nonResourceURLs:
       - "/metrics"


### PR DESCRIPTION
Part of the exporter's new approach to filter throttled pipelineruns because of the pipeline controller's aggressiver requeue strategy with throttling is that it labels the pipelinerun for later filtering.  However, the original introduction of the changes did not add patch permissions to the exporter's RBAC.  This change addresses that.

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED