### PR TITLE
Fix skip downgrade test for OSP nightly updates

### DIFF
--- a/.tekton/pipeline-service-upgrade-test-ocp-414.yaml
+++ b/.tekton/pipeline-service-upgrade-test-ocp-414.yaml
@@ -25,8 +25,8 @@ spec:
       value: "{{ revision }}"
     - name: target_branch
       value: "{{ target_branch }}"
-    - name: pr_title
-      value: "{{ body.pull_request.title }}"
+    - name: source_branch
+      value: "{{ source_branch }}"
   timeouts:
     pipeline: "1h30m0s"
   workspaces:

--- a/.tekton/pipeline/test-pipeline-service-upgrade.yaml
+++ b/.tekton/pipeline/test-pipeline-service-upgrade.yaml
@@ -8,7 +8,7 @@ spec:
     - name: repo_url
     - name: revision
     - name: target_branch
-    - name: pr_title
+    - name: source_branch
   timeouts:
     finally: "0h30m0s"
   workspaces:
@@ -112,9 +112,9 @@ spec:
       taskRef:
         name: deploy-pipeline-service
       when:
-        - input: "$(params.pr_title)"
+        - input: "$(params.source_branch)"
           operator: notin
-          values: ["[DO-NOT-MERGE] Automated change to update OSP nightly"]
+          values: ["ci-update-osp-nightly"]
       runAfter:
         - "test-upgrade"
       workspaces:
@@ -131,9 +131,9 @@ spec:
       taskRef:
         name: test-pipeline-service
       when:
-        - input: "$(params.pr_title)"
+        - input: "$(params.source_branch)"
           operator: notin
-          values: ["[DO-NOT-MERGE] Automated change to update OSP nightly"]
+          values: ["ci-update-osp-nightly"]
       runAfter:
         - "downgrade-pipeline-service"
       params:


### PR DESCRIPTION
Initially based on PR title which did not work as expected. Now based on source_branch, confirmed working on both new PR (create and update) and /test comment.