### PR TITLE
Add cronjob trigger to OSP nightly workflow

### DIFF
--- a/.github/workflows/update-osp-nightly.yaml
+++ b/.github/workflows/update-osp-nightly.yaml
@@ -1,7 +1,10 @@
 ---
 name: update-osp-nightly
 run-name: Check for OSP nightly and create a PR
-on: workflow_dispatch
+on:
+  schedule:
+    - cron: '10 1 * * *'
+  workflow_dispatch:
 permissions: {}  # drop all permissions; the default triggers codecov failure
 jobs:
   update-osp-nightly:


### PR DESCRIPTION
The intention always was to use a scheduler to execute the workflow daily. The manual trigger is kept for both easier testing and emergency updates.