### PR TITLE
PLNSRVCE-1526: expose core tekton webhook replicas setting in operator TektonConfig

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -43,6 +43,15 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    options:
+      disabled: false
+      deployments:
+        tekton-operator-proxy-webhook:
+          spec:
+            replicas: 1
+        tekton-pipelines-webhook:
+          spec:
+            replicas: 1
     performance:
       disable-ha: false
       buckets: 1


### PR DESCRIPTION
rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED

From local testing:
```
tekton-operator-proxy-webhook-7f6d7f7d74-bf6xs       1/1     Running     0          2m31s
tekton-operator-proxy-webhook-7f6d7f7d74-mtcdr       1/1     Running     0          2m31s
tekton-pipelines-webhook-84c6fc988d-2kqzd            1/1     Running     0          2m32s
tekton-pipelines-webhook-84c6fc988d-srwdz            1/1     Running     0          2m32s
```

After seeing tests pass here with 2 replicas, I'll move down back to one replica, and bump the replicas via a gitops patch in infra-deployments

@openshift-pipelines/pipelines-service  FYI

