### PR TITLE
Migrate Tekton Chains to an ExternalSecret

### DIFF
--- a/developer/openshift/gitops/local/kustomization.yaml
+++ b/developer/openshift/gitops/local/kustomization.yaml
@@ -2,8 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - https://github.com/owner/repository.git/path/gitops/argocd?ref=branch # Keep this item first in the list.
+  - openshift-pipelines
   - tekton-results
-  - https://github.com/owner/repository.git/path/gitops/argocd?ref=branch
 patches:
   - path: patch-pipeline-service.yaml
   - path: patch-pipeline-service-storage.yaml

--- a/developer/openshift/gitops/local/openshift-pipelines/chains-secrets-config.yaml
+++ b/developer/openshift/gitops/local/openshift-pipelines/chains-secrets-config.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tekton-chains-signing-secret
+  namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation  # Delete the job so it can be recreated and updated during the sync.
+spec:
+  template:
+    spec:
+      containers:
+        - name: chains-secret-generation
+          image: quay.io/redhat-appstudio/appstudio-utils:dbbdd82734232e6289e8fbae5b4c858481a7c057
+          imagePullPolicy: Always
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+
+              namespace="openshift-pipelines"
+              secret="signing-secrets"
+
+              if [ "$(kubectl get secret "$secret" -n "$namespace" -o jsonpath='{.data}' --ignore-not-found --allow-missing-template-keys)" != "" ]; then
+                echo "Signing secret exists and is non-empty."
+              else
+                # Delete secret/signing-secrets if already exists since by default cosign creates immutable secrets
+                kubectl delete secrets "$secret" -n "$namespace" --ignore-not-found=true
+
+                # To make this run conveniently without user input let's create a random password
+                RANDOM_PASS=$( openssl rand -base64 30 )
+
+                # Generate the key pair secret directly in the cluster.
+                echo "Generating k8s secret/$secret in $namespace with key-pair"
+                env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair "k8s://$namespace/$secret"
+              fi
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+            limits:
+              cpu: 100m
+              memory: 250Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      terminationGracePeriodSeconds: 30
+      serviceAccount: chains-secrets-admin
+      serviceAccountName: chains-secrets-admin

--- a/developer/openshift/gitops/local/openshift-pipelines/kustomization.yaml
+++ b/developer/openshift/gitops/local/openshift-pipelines/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - chains-secrets-config.yaml
+  - namespace.yaml

--- a/developer/openshift/gitops/local/openshift-pipelines/namespace.yaml
+++ b/developer/openshift/gitops/local/openshift-pipelines/namespace.yaml
@@ -1,0 +1,10 @@
+# Solves https://issues.redhat.com/browse/PLNSRVCE-1620
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-pipelines
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
@@ -9,9 +9,9 @@ resources:
   - tekton-config.yaml
   - config-logging.yaml
   - chains-service-monitor.yaml
+  - public-key-secret.yaml
   - bugfix-pac-gitauth-secrets.yaml
   # Manually add ConfigMap and Service until PLNSRVCE-1359 is fixed
   - chains-observability-service.yaml
   - chains-public-key-viewer.yaml
-  - chains-secrets-config.yaml
   - namespace.yaml

--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/public-key-secret.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/public-key-secret.yaml
@@ -46,7 +46,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: tekton-chains-signing-secret
+  name: tekton-chains-public-key
   namespace: openshift-pipelines
   annotations:
     argocd.argoproj.io/sync-wave: "1"
@@ -55,7 +55,7 @@ spec:
   template:
     spec:
       containers:
-        - name: chains-secret-generation
+        - name: chains-public-key-generation
           image: quay.io/redhat-appstudio/appstudio-utils:dbbdd82734232e6289e8fbae5b4c858481a7c057
           imagePullPolicy: Always
           command:
@@ -69,30 +69,9 @@ spec:
               namespace="openshift-pipelines"
               secret="signing-secrets"
 
-              cd /tmp
-
-              if [ "$(kubectl get secret "$secret" -n "$namespace" -o jsonpath='{.data}' --ignore-not-found --allow-missing-template-keys)" != "" ]; then
-                echo "Signing secret exists and is non-empty."
-              else
-                # Delete secret/signing-secrets if already exists since by default cosign creates immutable secrets
-                kubectl delete secrets "$secret" -n "$namespace" --ignore-not-found=true
-
-                # To make this run conveniently without user input let's create a random password
-                RANDOM_PASS=$( openssl rand -base64 30 )
-
-                # Generate the key pair secret directly in the cluster.
-                # The secret should be created as immutable.
-                echo "Generating k8s secret/$secret in $namespace with key-pair"
-                env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair "k8s://$namespace/$secret"
-              fi
-
-              # If the secret is not marked as immutable, make it so.
-              if [ "$(kubectl get secret "$secret" -n "$namespace" -o jsonpath='{.immutable}')" != "true" ]; then
-                echo "Making secret immutable"
-                kubectl patch secret "$secret" -n "$namespace" --dry-run=client -o yaml \
-                  --patch='{"immutable": true}' \
-                | kubectl apply -f -
-              fi
+              while [ "$(kubectl get secret "$secret" -n "$namespace" -o jsonpath='{.data}' --ignore-not-found --allow-missing-template-keys)" == "" ]; do
+                echo "Signing secret is empty."
+              done
 
               echo "Generating/updating the secret with the public key"
               kubectl create secret generic public-key \

--- a/operator/test/test.sh
+++ b/operator/test/test.sh
@@ -89,7 +89,7 @@ setup_test() {
 wait_for_pipeline() {
   if ! kubectl wait --for=condition=succeeded "$1" -n "$2" --timeout 300s >"$DEBUG_OUTPUT"; then
     echo "[ERROR] Pipeline failed to complete successful" >&2
-    kubectl get pipelineruns "$1" -n "$2" >"$DEBUG_OUTPUT"
+    kubectl get "$1" -n "$2" >"$DEBUG_OUTPUT"
     exit 1
   fi
 }
@@ -160,11 +160,6 @@ test_chains() {
     echo "[ERROR] Secret does not exist" >&2
     exit 1
   fi
-  if [ "$(kubectl get secret signing-secrets -n openshift-pipelines -o jsonpath='{.immutable}')" != "true" ]; then
-    echo "Failed"
-    echo "[ERROR] Secret is not immutable" >&2
-    exit 1
-  fi
   echo "OK"
 
   # Trigger the pipeline
@@ -230,20 +225,6 @@ test_chains() {
     echo "[ERROR] Public key is not accessible" >&2
     exit 1
   fi
-
-  # TODO: Reactivate on step 2/3 of the migration.
-  # This test is not critical until we ask EC to use the openshift-pipelines namespace.
-  # echo -n "  - Public key migration: "
-  # pipeline_name=$(kubectl create -f "$SCRIPT_DIR/manifests/test/tekton-chains/public-key-migration.yaml" -n "$NAMESPACE" | cut -d' ' -f1)
-  # wait_for_pipeline "$pipeline_name" "$NAMESPACE"
-  # if [ "$(kubectl get "$pipeline_name" -n "$NAMESPACE" \
-  #   -o 'jsonpath={.status.conditions[0].reason}')" = "Succeeded" ]; then
-  #   echo "OK"
-  # else
-  #   echo "Failed"
-  #   echo "[ERROR] Public key is not accessible" >&2
-  #   exit 1
-  # fi
 
   echo -n "  - Metrics: "
   prName="$(kubectl create -n "$NAMESPACE" -f "$SCRIPT_DIR/manifests/test/tekton-chains/tekton-chains-metrics.yaml" | awk '{print $1}')"


### PR DESCRIPTION
In order to facilitate backup/restore of a cluster, the signing secret is now stored externally and deployed on the cluster using an ExternalSecret.

The original behavior is maintained for local development.

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED