### PR TITLE
PLNSRVCE-1625: disable beta api feature fields and enable alpha field…

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -45,7 +45,7 @@ spec:
     transparency.enabled: "false"
   pipeline:
     default-service-account: appstudio-pipeline
-    enable-api-fields: beta
+    enable-api-fields: alpha
     enable-bundles-resolver: true
     enable-cluster-resolver: true
     enable-git-resolver: true


### PR DESCRIPTION
konflux users want to be able to set resources at step level in the pipeline definition.
Acutally using computeResources at PipelineTaskRunSpec is not inconvenient, because the setting per task gets divided per step. Users want to have fined grained resources configurations at step level.
Using stepSpecs (refre to the doc and code ) is covering the user requirement, but it needs to set feature fiels to alpha for tektonconfig. As far as i tested, I am not seen any regression du this new setting.

https://github.com/tektoncd/pipeline/blob/018c4b84bf850d4cc1565863dab281ad07abc069/pkg/apis/pipeline/v1/pipelinerun_types.go#L637
https://tekton.dev/docs/pipelines/pipeline-api/#tekton.dev/v1.PipelineTaskRunSpec

for the record here is a manifest for testing the feature
```yaml apiVersion: tekton.dev/v1
kind: PipelineRun
metadata:
  name: hello-34
spec:
  taskRunSpecs:
    - pipelineTaskName: hello
      stepSpecs:
      - name: hello
        computeResources:
          limits:
            cpu: 100m
            memory: 100Mi
          requests:
              cpu: 50m
              memory: 50Mi
  pipelineSpec:
    tasks:
      - name: hello
        taskSpec:
          steps:
            - name: hello
              image: ubuntu
              script: "echo hello world!"`