### PR TITLE
PLNSRVCE-1526: expose in tektonconfig all relevant tekton deployments replicas count in openshift-pipelines

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -19,6 +19,14 @@ spec:
     openshift:
       pipelinesAsCode:
         enable: true
+        options:
+          deployments:
+            pipelines-as-code-watcher:
+              spec:
+                replicas: 1
+            pipelines-as-code-webhook:
+              spec:
+                replicas: 1
   chain:
     # Configure TaskRun attestation.
     # RHTAP does not leverage the TaskRun attestations.
@@ -33,6 +41,11 @@ spec:
     artifacts.pipelinerun.format: "in-toto"
     artifacts.pipelinerun.storage: "oci"
 
+    options:
+      deployments:
+        tekton-chains-controller:
+          spec:
+            replicas: 1
     # Rekor integration is disabled for now. It is planned to be re-introduced in the future.
     transparency.enabled: "false"
   pipeline:
@@ -49,7 +62,7 @@ spec:
         tekton-operator-proxy-webhook:
           spec:
             replicas: 1
-        tekton-pipelines-webhook:
+        tekton-pipelines-remote-resolvers:
           spec:
             replicas: 1
     performance:


### PR DESCRIPTION
This will include:
- chains controller
- PAC watcher and webhook; PAC controller currently does not have an upstream leader election config map
- remote resolvers controller
- any other core tekton stuff like eventing or triggers are not employed by Konflux
- reminder, the core tekton pipeline webhook has a horizontal autopod scaler that controlls the webhook's replica count

Validated with 2 replicas with local testing before setting back to 1

@openshift-pipelines/pipelines-service FYI / PTAL

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED