### PR TITLE
PLNSRVCE-1526: expose results watcher replica count in yaml

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
+  replicas: 1
   template:
     spec:
       containers:


### PR DESCRIPTION
Manual testing with 2 replicas validated that leader election wired and functioning properly

Will override in infra-deployments

@openshift-pipelines/pipelines-service FYI

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED