### PR TITLE
PLNSRVCE-1526: revert chain replica exposure in tektonconfig

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -41,11 +41,6 @@ spec:
     artifacts.pipelinerun.format: "in-toto"
     artifacts.pipelinerun.storage: "oci"
 
-    options:
-      deployments:
-        tekton-chains-controller:
-          spec:
-            replicas: 1
     # Rekor integration is disabled for now. It is planned to be re-introduced in the future.
     transparency.enabled: "false"
   pipeline:


### PR DESCRIPTION
While it appears addons are available in master branch for the chains type, prior testing seems to have been erroneous, and the setting is not sticking at 1.13.x.  Will attempt at a later date.

@openshift-pipelines/pipelines-service FYI

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED