### PR TITLE
PLNSRVCE-1526: add affinity policies to results watcher

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
@@ -10,6 +10,23 @@ spec:
   replicas: 1
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: NotIn
+                    values:
+                      - windows
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: tekton-results-watcher
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       containers:
         - name: watcher
           args:


### PR DESCRIPTION
Discovered the need for this as a result of https://github.com/redhat-appstudio/infra-deployments/pull/3252#issuecomment-1937835777

Short term, the situation with the bitnami images and postgresql will sabatoge CI, but a manual apply -k of yaml shows the deployment is created fine and the watcher pod is started successfully

@openshift-pipelines/pipelines-service FYI

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED