### PR TITLE
Remove SCRIPT_IMAGE param from update infra-deployments task

### DIFF
--- a/.tekton/open-infra-deployment-pr-osp-nightly.yaml
+++ b/.tekton/open-infra-deployment-pr-osp-nightly.yaml
@@ -41,8 +41,6 @@ spec:
             value: $(params.git-url)
           - name: REVISION
             value: $(params.revision)
-          - name: SCRIPT_IMAGE
-            value: quay.io/devtools_gitops/test_image:4.0.5
           - name: SCRIPT
             value: $(params.infra-deployment-update-script)
         taskRef:

--- a/.tekton/open-infra-deployment-pr.yaml
+++ b/.tekton/open-infra-deployment-pr.yaml
@@ -18,9 +18,9 @@ spec:
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/development/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/staging/base/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
-        kustomize build components/pipeline-service/staging/stone-stg-m01/resources/ > components/pipeline-service/staging/stone-stg-m01/deploy.yaml
-        kustomize build components/pipeline-service/staging/stone-stg-rh01/resources/ > components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
-        kustomize build components/pipeline-service/staging/stone-stage-p01/resources/ > components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+        oc kustomize build components/pipeline-service/staging/stone-stg-m01/resources/ > components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+        oc kustomize build components/pipeline-service/staging/stone-stg-rh01/resources/ > components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+        oc kustomize build components/pipeline-service/staging/stone-stage-p01/resources/ > components/pipeline-service/staging/stone-stage-p01/deploy.yaml
     - name: slack-webhook-notification-team
       value: pipeline
   pipelineSpec:
@@ -42,8 +42,6 @@ spec:
             value: $(params.git-url)
           - name: REVISION
             value: $(params.revision)
-          - name: SCRIPT_IMAGE
-            value: quay.io/devtools_gitops/test_image:4.0.5
           - name: SCRIPT
             value: $(params.infra-deployment-update-script)
         taskRef:


### PR DESCRIPTION
The task we reference in the PipelineRun
quay.io/redhat-appstudio-tekton-catalog/task-slack-webhook-notification:0.1 is changed and the SCRIPT_IMAGE parameter removed. Instead a default image is used.
ref: https://github.com/redhat-appstudio/build-definitions/pull/792

The new image does not have `kustomize`, but it has `oc`, so we use `oc kustomize` instead.