### PR TITLE
Remove the developer/devenv image from the CI

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -30,10 +30,6 @@ jobs:
               - '.github/workflows/build-push-images.yaml'
               - 'developer/images/dependencies/**'
               - 'shared/**'
-            devenv:
-              - '.github/workflows/build-push-images.yaml'
-              - 'developer/images/devenv/**'
-              - 'shared/**'
             e2e-test-runner:
               - '.github/workflows/build-push-images.yaml'
               - 'ci/images/e2e-test-runner/**'
@@ -151,42 +147,6 @@ jobs:
         if: steps.filter.outputs.dependencies-update != 'true'
         env:
           image: dependencies-update
-          registry: quay.io/redhat-pipeline-service
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-        run: |
-          ./ci/images/quay-upload/image-upload.sh --debug
-
-      # Build and push devenv image, tagged with the branch name and the commit SHA.
-      - name: Build devenv Image
-        id: build-image-devenv
-        if: steps.filter.outputs.devenv == 'true'
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: devenv
-          context: .
-          tags: latest ${{ steps.vars.outputs.sha_short }} ${{ github.ref_name }}
-          containerfiles: |
-            ./developer/images/devenv/Dockerfile
-      - name: Push to quay.io
-        id: push-to-quay-devenv
-        if: steps.filter.outputs.devenv == 'true'
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image-devenv.outputs.image }}
-          tags: ${{ steps.build-image-devenv.outputs.tags }} ${{ github.ref_name }}
-          registry: quay.io/redhat-pipeline-service
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-      - name: Print image url
-        if: steps.filter.outputs.devenv == 'true'
-        run: |
-          echo "Image pushed to ${{ steps.push-to-quay-devenv.outputs.registry-paths }}"
-      - name: Tag latest commit ID to quay.io
-        id: tag-commit-quay-devenv
-        if: steps.filter.outputs.devenv != 'true'
-        env:
-          image: devenv
           registry: quay.io/redhat-pipeline-service
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/individual-image-scanner-quay.yaml
+++ b/.github/workflows/individual-image-scanner-quay.yaml
@@ -25,7 +25,6 @@ jobs:
       ci-runner-output: ${{ steps.ci-runner-scan.outputs.VULNERABILITIES_EXIST }}
       dependencies-update-output: ${{ steps.dependencies-update-scan.outputs.VULNERABILITIES_EXIST }}
       e2e-test-runner-output: ${{ steps.e2e-test-runner-scan.outputs.VULNERABILITIES_EXIST }}
-      devenv-output: ${{ steps.devenv-scan.outputs.VULNERABILITIES_EXIST }}
       quay-upload-output: ${{ steps.quay-upload-scan.outputs.VULNERABILITIES_EXIST }}
       static-checks-output: ${{ steps.static-checks-scan.outputs.VULNERABILITIES_EXIST }}
       vulnerability-scan-output: ${{ steps.vulnerability-scan.outputs.VULNERABILITIES_EXIST }}
@@ -42,9 +41,6 @@ jobs:
             dependencies-update:
               - '.github/workflows/build-push-images.yaml'
               - 'developer/images/dependencies/**'
-              - 'shared/**'
-            devenv:
-              - 'developer/images/devenv/**'
               - 'shared/**'
             e2e-test-runner:
               - 'ci/images/e2e-test-runner/**'
@@ -76,16 +72,6 @@ jobs:
           echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
         env:
           IMAGE_NAME: dependencies-update
-
-      - name: devenv scan
-        continue-on-error: true
-        id: devenv-scan
-        if: steps.filter.outputs.devenv == 'true'
-        run: |
-          ./ci/images/vulnerability-scan/scan-image.sh | tee /tmp/clair-scan.log
-          echo "VULNERABILITIES_EXIST=$(tail -1 /tmp/clair-scan.log)" >> $GITHUB_OUTPUT
-        env:
-          IMAGE_NAME: devenv
 
       - name: quay-upload scan
         continue-on-error: true
@@ -153,19 +139,6 @@ jobs:
           res=${res:=0}
           if [[ $res != 0 ]]; then
             echo "Vulnerabilities found with dependencies-update image. Please check scans job for more details."
-            exit 1
-          else
-            echo "No vulnerabilities found"
-          fi
-
-      - name: Check devenv results
-        id: check-devenv-results
-        if: always()
-        run: |
-          res=${{ needs.scans.outputs.devenv-output }}
-          res=${res:=0}
-          if [[ $res != 0 ]]; then
-            echo "Vulnerabilities found with devenv image. Please check scans job for more details."
             exit 1
           else
             echo "No vulnerabilities found"

--- a/.github/workflows/periodic-scanner-quay.yaml
+++ b/.github/workflows/periodic-scanner-quay.yaml
@@ -25,7 +25,6 @@ jobs:
           images: (
             "ci-runner"
             "dependencies-update"
-            "devenv"
             "e2e-test-runner"
             "quay-upload"
             "static-checks"


### PR DESCRIPTION
The image is brittle because the image tag is floating. Since the image is just used for development, it should not be an issue to remove it from the CI.

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED