### PR TITLE
Fix git RPM version no longer available

### DIFF
--- a/developer/images/devenv/Dockerfile
+++ b/developer/images/devenv/Dockerfile
@@ -5,7 +5,7 @@ RUN set -x \
     && dnf install -y \
         # gcc is needed when installing checkov's dependencies
         gcc-c++-13.2.1 \
-        git-2.43.0 \
+        git-2.43.2 \
         openssl-3.1.1 \
         procps-ng-4.0.3 \
         # python3-devl is needed when installing checkov's dependencies


### PR DESCRIPTION
The git-2.43.0 version is no longer available, making the Dockerfile build (part of test-docker-images-build job) fail.