### PR TITLE
Update the GH action checking and updating nightlies

### DIFF
--- a/.github/workflows/update-osp-nightly.yaml
+++ b/.github/workflows/update-osp-nightly.yaml
@@ -23,10 +23,6 @@ jobs:
           digest=$(echo "$inspected" | jq -r '.Digest')
           echo "DEBUG: Tag digest: $digest"
           sed -i -E "s/sha256:[0-9a-f]{64}/${digest}/g" operator/gitops/argocd/pipeline-service/openshift-pipelines/osp-nightly-catalog-source.yaml
-      - name: Enable CatalogSource  # Could be removed once we switch to nightly builds
-        run: yq -i '.resources += "osp-nightly-catalog-source.yaml"' operator/gitops/argocd/pipeline-service/openshift-pipelines/kustomization.yaml
-      - name: Update Subscription  # Could be removed once we switch to nightly builds
-        run: yq -i '.spec.channel = "latest" | .spec.source = "custom-operators"' operator/gitops/argocd/pipeline-service/openshift-pipelines/openshift-operator.yaml
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
@@ -34,9 +30,6 @@ jobs:
           # and skip downgrade tests.
           branch: ci-update-osp-nightly
           commit-message: "[new-osp-nightly-build] automated change"
-          title: "[DO-NOT-MERGE] Automated change to update OSP nightly"
+          title: "Automated change updating the OSP nightly version"
           body: |
             Automated change by [update-osp-nightly]
-
-            The change is only intended to test the nightly build in the CI.
-            Do not merge!


### PR DESCRIPTION
With Pipeline Service switching to nightlies, we customize the auto-generated PR and remove changes which are already part of the work tree.