### PR TITLE
expose autoscaler for both webhooks

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -56,10 +56,68 @@ spec:
       deployments:
         tekton-operator-proxy-webhook:
           spec:
-            replicas: 1
+            template:
+              spec:
+                containers:
+                  - name: proxy
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 100Mi
+                      limits:
+                        cpu: 500m
+                        memory: 500Mi
+        tekton-pipelines-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: webhook
+                    resources:
+                      requests:
+                        cpu: 200m
+                        memory: 200Mi
+                      limits:
+                        cpu: '1'
+                        memory: 1Gi
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 1
+      horizontalPodAutoscalers:
+        tekton-pipelines-webhook:
+          spec:
+            maxReplicas: 6
+            minReplicas: 2
+            metrics:
+              - resource:
+                  name: cpu
+                  target:
+                    averageUtilization: 100
+                    type: Utilization
+                type: Resource
+              - resource:
+                  name: memory
+                  target:
+                    averageUtilization: 100
+                    type: Utilization
+                type: Resource
+        tekton-operator-proxy-webhook:
+          spec:
+            maxReplicas: 6
+            minReplicas: 2
+            metrics:
+              - resource:
+                  name: cpu
+                  target:
+                    averageUtilization: 100
+                    type: Utilization
+                type: Resource
+              - resource:
+                  name: memory
+                  target:
+                    averageUtilization: 100
+                    type: Utilization
+                type: Resource
     performance:
       disable-ha: false
       buckets: 1

--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-s3-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-s3-config.yaml
@@ -44,8 +44,8 @@ spec:
                   name: tekton-results-s3
           resources:
             requests:
-              cpu: 5m
-              memory: 128Mi
+              cpu: 100m
+              memory: 512Mi
             limits:
               cpu: 100m
               memory: 512Mi

--- a/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/watcher-config.yaml
@@ -38,11 +38,13 @@ spec:
               "-check_owner=false",
               "-completed_run_grace_period",
               "10m",
+              "-threadiness",
+              "32",
             ]
           resources:
             requests:
-              cpu: 100m
-              memory: 64Mi
+              cpu: 250m
+              memory: 2Gi
             limits:
               cpu: 250m
               memory: 2Gi


### PR DESCRIPTION
add req/limit for operator proxy webhook
double req/limit for core webhook
equate results api/watcher requests/limits cpu/mem results watcher controller perf settings

As part of either the nightlies exposing 1.14+, or an explicit switch to 1.14 if something blocks nightly propagation, 
I'm exposing horizontal pod autoscalers and related deployment cpu/mem req/limit for the webhooks.

there was some results req/limit settings that needed to be made equal to ensure obtaining of those value from k8s, as we saw some instances where more mem was denied while below the mem limit 

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED