### PR TITLE
bump test docker image build timeout to 1 hour

### DIFF
--- a/.tekton/test-docker-images-build.yaml
+++ b/.tekton/test-docker-images-build.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   timeouts:
-    pipeline: "0h20m0s"
+    pipeline: "1h0m0s"
   params:
     - name: repo_url
       value: "{{ repo_url }}"


### PR DESCRIPTION
rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED

seeing img build timeouts today in PR CI