### PR TITLE
Remove immutability to chains signing-secrets

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
@@ -86,14 +86,6 @@ spec:
                 env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair "k8s://$namespace/$secret"
               fi
 
-              # If the secret is not marked as immutable, make it so.
-              if [ "$(kubectl get secret "$secret" -n "$namespace" -o jsonpath='{.immutable}')" != "true" ]; then
-                echo "Making secret immutable"
-                kubectl patch secret "$secret" -n "$namespace" --dry-run=client -o yaml \
-                  --patch='{"immutable": true}' \
-                | kubectl apply -f -
-              fi
-
               echo "Generating/updating the secret with the public key"
               kubectl create secret generic public-key \
                 --namespace "$namespace" \

--- a/operator/test/test.sh
+++ b/operator/test/test.sh
@@ -160,11 +160,6 @@ test_chains() {
     echo "[ERROR] Secret does not exist" >&2
     exit 1
   fi
-  if [ "$(kubectl get secret signing-secrets -n openshift-pipelines -o jsonpath='{.immutable}')" != "true" ]; then
-    echo "Failed"
-    echo "[ERROR] Secret is not immutable" >&2
-    exit 1
-  fi
   echo "OK"
 
   # Trigger the pipeline


### PR DESCRIPTION
Now that the secret is managed by an ExternalSecret, the secret should not be immutable so the secret can be synced.

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED