### PR TITLE
Update the update-osp-nightly GH action

### DIFF
--- a/.github/workflows/update-osp-nightly.yaml
+++ b/.github/workflows/update-osp-nightly.yaml
@@ -24,7 +24,7 @@ jobs:
           echo "DEBUG: Tag digest: $digest"
           sed -i -E "s/sha256:[0-9a-f]{64}/${digest}/g" operator/gitops/argocd/pipeline-service/openshift-pipelines/osp-nightly-catalog-source.yaml
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           # the branch name is used by other jobs to open infra-deployments PR
           # and skip downgrade tests.


### PR DESCRIPTION
The peter-evans/create-pull-request GH action has newer version fixing the "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20" error.