### PR TITLE
set explicit resources for tekton results api pod

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/api-resources-patch.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/api-resources-patch.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-api
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 500Mi
+            limits:
+              memory: 1000Mi
+              cpu: null

--- a/operator/gitops/argocd/pipeline-service/tekton-results/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/kustomization.yaml
@@ -33,6 +33,7 @@ patches:
   - path: api-sync.yaml
   - path: api-service-sync.yaml
   - path: api-service-tls.yaml
+  - path: api-resources-patch.yaml
   - path: watcher-config.yaml
   - path: watcher-logging.yaml
   - path: watcher-sync.yaml


### PR DESCRIPTION
- CPU limits removed, memory limit set to 1000Mi
- CPU request set to 1000m and memory request to 500Mi

Signed-off-by: Avinal Kumar <avinal@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED
