### PR TITLE
Use newer Tekton Results version

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tekton-results
 resources:
-  - https://github.com/openshift-pipelines/tektoncd-results.git/config/overlays/base-only/?ref=a602fb3e858f6a3195374d2175053db7e5db9f77
+  - https://github.com/openshift-pipelines/tektoncd-results.git/config/overlays/base-only/?ref=bae7851ff584423503af324200f52cd28ca99116
   - namespace.yaml
   - api-route.yaml
   - watcher-logging-rbac.yaml
@@ -13,10 +13,10 @@ resources:
 images:
   - name: ko://github.com/tektoncd/results/cmd/api
     newName: quay.io/redhat-appstudio/tekton-results-api
-    newTag: a602fb3e858f6a3195374d2175053db7e5db9f77
+    newTag: bae7851ff584423503af324200f52cd28ca99116
   - name: ko://github.com/tektoncd/results/cmd/watcher
     newName: quay.io/redhat-appstudio/tekton-results-watcher
-    newTag: a602fb3e858f6a3195374d2175053db7e5db9f77
+    newTag: bae7851ff584423503af324200f52cd28ca99116
 
 # generate a new configmap with updated values (logs api, db ssl mode) and replace the default one
 configMapGenerator:


### PR DESCRIPTION
Use newer Tekton Results version including the "Support all data types in summary annotations" (fix for the json unmarshal bug). Drop the "employ some channel best practices to avoid hanging goroutines and memory leaks from unclosed buffered channels" commit.

The commit is from the downstream-0.9.1-03-no-21d96ba branch on the Results fork.