### PR TITLE
Enable deep-inspection for Chains in tekton config

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -43,6 +43,9 @@ spec:
 
     # Rekor integration is disabled for now. It is planned to be re-introduced in the future.
     transparency.enabled: "false"
+
+    # Configure deep inspection
+    artifacts.pipelinerun.enable-deep-inspection: "true"
   trigger:
     options:
       configMaps:


### PR DESCRIPTION
This config change enables Chains to inspect task level results making sure the index manifests for an image index get attested too and not just the image index iself.

Resolved CVP-4070