### PR TITLE
fix flaky tekton results api success rate panel

### DIFF
--- a/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
+++ b/operator/gitops/argocd/grafana/dashboards/pipeline-service-dashboard.json
@@ -2597,17 +2597,21 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "continuous-RdYlGr"
+                "mode": "thresholds"
               },
               "mappings": [],
               "max": 1,
               "min": 0,
               "noValue": "No Data",
               "thresholds": {
-                "mode": "percentage",
+                "mode": "absolute",
                 "steps": [
                   {
                     "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 94
                   }
                 ]
               },
@@ -2622,7 +2626,6 @@
             "y": 17
           },
           "id": 62,
-          "interval": "15s",
           "options": {
             "colorMode": "value",
             "graphMode": "area",
@@ -2630,7 +2633,7 @@
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
-                "mean"
+                "lastNotNull"
               ],
               "fields": "",
               "values": false
@@ -2642,10 +2645,12 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "1 - ((sum(rate(grpc_server_handled_total{job=\"tekton-results-api\", grpc_service=~\"tekton.results.v1alpha2.*\", grpc_code=~\"Internal|Unavailable|Unknown|Unimplemented\"}[$__rate_interval]))) / sum(rate(grpc_server_started_total{job=\"tekton-results-api\", grpc_service=~\"tekton.results.v1alpha2.*\"}[$__rate_interval])))\n",
+              "expr": "1 - sum(grpc_server_handled_total{job=\"tekton-results-api\", grpc_service=~\"tekton.results.v1alpha2.*\", grpc_code=~\"Internal|Unavailable|Unknown|Unimplemented|Canceled|Unauthenticated|ResourceExhausted|PermissionDenied|OutOfRange|InvalidArgument|FailedPrecondition|DeadlineExceeded|DataLoss|Aborted\"}) / sum(grpc_server_handled_total{job=\"tekton-results-api\", grpc_service=~\"tekton.results.v1alpha2.*\"})",
+              "format": "table",
+              "hide": false,
+              "instant": false,
               "interval": "",
-              "intervalFactor": 4,
-              "legendFormat": "Success Rate",
+              "legendFormat": "",
               "refId": "request success rate"
             }
           ],


### PR DESCRIPTION
So the grafana suggested use of rate proved flaky in prod for what we need for the tekton results api success rate for basic debug, which includes historical

![prod-results-api-success-rate](https://github.com/openshift-pipelines/pipeline-service/assets/3594868/a8c4ccff-5f78-4a35-aa72-4ea54f2125a0)

If we were ever to use this for alerts, we'll add a panel that does the `increase(...)` to adjust for resets, etc.

for more on rate vs. increase some internet searching will get you deep dive break downs like https://stackoverflow.com/questions/54494394/do-i-understand-prometheuss-rate-vs-increase-functions-correctly

We now have 

![fixed-tekton-results-api-success-rate](https://github.com/openshift-pipelines/pipeline-service/assets/3594868/6096cb2f-e831-45fc-ac34-3fd70b783b9f)

@jkhelil @enarha ptal

@savitaashture fyi

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED