### PR TITLE
enable pprof on metrics exporter

### DIFF
--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
@@ -20,7 +20,11 @@ spec:
       containers:
         - name: pipeline-metrics-exporter
           image: quay.io/redhat-appstudio/pipeline-service-exporter:placeholder
-          args: []
+          args:
+            [
+              "-pprof-address",
+              "6060",
+            ]
           ports:
             - containerPort: 9117
               name: metrics


### PR DESCRIPTION
per https://go.dev/doc/diagnostics it is safe to run with pprof in production, where the only perf impact of any note is if you explicitly enable cpu profiling or tracing.

this allows us to do spot profiling, or minimally, get thread dumps with ease.

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED