### PR TITLE
pin watcher to mem leak version, revert latest fix attempt

### DIFF
--- a/.tekton/open-infra-deployment-pr-osp-nightly.yaml
+++ b/.tekton/open-infra-deployment-pr-osp-nightly.yaml
@@ -18,7 +18,11 @@ spec:
     - name: infra-deployment-update-script
       value: |
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/development/kustomization.yaml
+        # just pin the watcher image, which is the second image ref
+        yq -e -i '.images[1].newTag = "bae7851ff584423503af324200f52cd28ca99116"' components/pipeline-service/development/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/staging/base/kustomization.yaml
+        # just pin the watcher image, which is the second image ref
+        yq -e -i '.images[1].newTag = "bae7851ff584423503af324200f52cd28ca99116"' components/pipeline-service/staging/base/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
     - name: slack-webhook-notification-team
       value: pipeline

--- a/.tekton/open-infra-deployment-pr.yaml
+++ b/.tekton/open-infra-deployment-pr.yaml
@@ -16,7 +16,11 @@ spec:
     - name: infra-deployment-update-script
       value: |
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/development/kustomization.yaml
+        # just pin the watcher image, which is the second image ref
+        yq -e -i '.images[1].newTag = "bae7851ff584423503af324200f52cd28ca99116"' components/pipeline-service/development/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/staging/base/kustomization.yaml
+        # just pin the watcher image, which is the second image ref
+        yq -e -i '.images[1].newTag = "bae7851ff584423503af324200f52cd28ca99116"' components/pipeline-service/staging/base/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
         oc kustomize components/pipeline-service/staging/stone-stg-m01/resources/ > components/pipeline-service/staging/stone-stg-m01/deploy.yaml
         oc kustomize components/pipeline-service/staging/stone-stg-rh01/resources/ > components/pipeline-service/staging/stone-stg-rh01/deploy.yaml


### PR DESCRIPTION
undo only half of https://github.com/openshift-pipelines/pipeline-service/pull/1007 as the older watcher and newest api server work OK together

let's keep the api server tuning options

@enarha PTAL

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED