### PR TITLE
Update only development

### DIFF
--- a/.tekton/open-infra-deployment-pr-osp-nightly.yaml
+++ b/.tekton/open-infra-deployment-pr-osp-nightly.yaml
@@ -18,8 +18,6 @@ spec:
     - name: infra-deployment-update-script
       value: |
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/development/kustomization.yaml
-        sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/staging/base/kustomization.yaml
-        sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
     - name: slack-webhook-notification-team
       value: pipeline
   pipelineSpec:


### PR DESCRIPTION
The changes generated by this pipelinerun are used to run the Konflux CI and that uses only `components/pipeline-service/development`. Removing the update of `components/pipeline-service/staging` and `components/monitoring/grafana/base/dashboards/pipeline-service` because it is not actually used and just adds "noise" to the changes.