### PR TITLE
switch back off yq for sed for pinning watcher image, but get it working

### DIFF
--- a/.tekton/open-infra-deployment-pr-osp-nightly.yaml
+++ b/.tekton/open-infra-deployment-pr-osp-nightly.yaml
@@ -19,10 +19,10 @@ spec:
       value: |
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/development/kustomization.yaml
         # just pin the watcher image, which is the second image ref
-        yq -e -i '.images[1].newTag = "bae7851ff584423503af324200f52cd28ca99116"' components/pipeline-service/development/kustomization.yaml
+        sed -i -E '/name: quay.io\/redhat-appstudio\/tekton-results-watcher/{n;s/newTag: {{ revision }}/newTag: bae7851ff584423503af324200f52cd28ca99116/}' components/pipeline-service/development/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/staging/base/kustomization.yaml
         # just pin the watcher image, which is the second image ref
-        yq -e -i '.images[1].newTag = "bae7851ff584423503af324200f52cd28ca99116"' components/pipeline-service/staging/base/kustomization.yaml
+        sed -i -E '/name: quay.io\/redhat-appstudio\/tekton-results-watcher/{n;s/newTag: {{ revision }}/newTag: bae7851ff584423503af324200f52cd28ca99116/}'  components/pipeline-service/staging/base/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
     - name: slack-webhook-notification-team
       value: pipeline

--- a/.tekton/open-infra-deployment-pr.yaml
+++ b/.tekton/open-infra-deployment-pr.yaml
@@ -17,10 +17,10 @@ spec:
       value: |
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/development/kustomization.yaml
         # just pin the watcher image, which is the second image ref
-        yq -e -i '.images[1].newTag = "bae7851ff584423503af324200f52cd28ca99116"' components/pipeline-service/development/kustomization.yaml
+        sed -i -E '/name: quay.io\/redhat-appstudio\/tekton-results-watcher/{n;s/newTag: {{ revision }}/newTag: bae7851ff584423503af324200f52cd28ca99116/}' components/pipeline-service/development/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/pipeline-service/staging/base/kustomization.yaml
         # just pin the watcher image, which is the second image ref
-        yq -e -i '.images[1].newTag = "bae7851ff584423503af324200f52cd28ca99116"' components/pipeline-service/staging/base/kustomization.yaml
+        sed -i -E '/name: quay.io\/redhat-appstudio\/tekton-results-watcher/{n;s/newTag: {{ revision }}/newTag: bae7851ff584423503af324200f52cd28ca99116/}'  components/pipeline-service/staging/base/kustomization.yaml
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
         oc kustomize components/pipeline-service/staging/stone-stg-m01/resources/ > components/pipeline-service/staging/stone-stg-m01/deploy.yaml
         oc kustomize components/pipeline-service/staging/stone-stg-rh01/resources/ > components/pipeline-service/staging/stone-stg-rh01/deploy.yaml


### PR DESCRIPTION
@enarha and I were able to test this locally

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED