### PR TITLE
Update appstudio-utils image ref

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/chains-secrets-config.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
         - name: chains-secret-generation
-          image: quay.io/redhat-appstudio/appstudio-utils:dbbdd82734232e6289e8fbae5b4c858481a7c057
+          image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
           imagePullPolicy: Always
           command:
             - /bin/bash


### PR DESCRIPTION
The change was wrongly introduced in the infra-deployments deploy.yaml files, making the updates from pipeline-service to override the change.
ref: https://github.com/redhat-appstudio/infra-deployments/pull/3848