### PR TITLE
Enable Tekton step-actions

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -84,6 +84,7 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    enable-step-actions: true
     options:
       disabled: false
       configMaps:


### PR DESCRIPTION
This is already enabled and used in Konflux (see
https://github.com/redhat-appstudio/infra-deployments/pull/3693 and https://github.com/redhat-appstudio/infra-deployments/pull/3818). Without having the configuration in pipeline-service, updates were overriding the values. This will not generate diff in Konflux.