### PR TITLE
SRVKP-5825: move to exporter image in quay.io/konflux-ci

### DIFF
--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: pipeline-service-exporter
       containers:
         - name: pipeline-metrics-exporter
-          image: quay.io/redhat-appstudio/pipeline-service-exporter:placeholder
+          image: quay.io/konflux-ci/pipeline-service-exporter:placeholder
           args:
             [
               "-pprof-address",

--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml
@@ -8,8 +8,8 @@ resources:
   - servicemonitor.yaml
 
 images:
-  - name: quay.io/redhat-appstudio/pipeline-service-exporter
-    newName: quay.io/redhat-appstudio/pipeline-service-exporter
+  - name: quay.io/konflux-ci/pipeline-service-exporter
+    newName: quay.io/konflux-ci/pipeline-service-exporter
     newTag: c18a1079e58315454fb3ddf2ea9dc3c5cd4dc954
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
this should properly consume the update from https://github.com/openshift-pipelines/pipeline-service-exporter/pull/70

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED