### PR TITLE
[DO-NOT-MERGE-YET] turn on pprof in core controller to allow for goroutine dumps

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -87,6 +87,14 @@ spec:
     options:
       disabled: false
       configMaps:
+        config-observability:
+          data:
+            metrics.count.enable-reason: 'false'
+            metrics.pipelinerun.duration-type: histogram
+            metrics.pipelinerun.level: pipeline
+            metrics.taskrun.duration-type: histogram
+            metrics.taskrun.level: task
+            profiling.enable: "true"
         config-logging:
           data:
             loglevel.controller: info

--- a/operator/gitops/argocd/pipeline-service/tekton-results/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/kustomization.yaml
@@ -26,6 +26,10 @@ configMapGenerator:
     name: api-config
     options:
       disableNameSuffixHash: true
+  - behavior: merge
+    name: config-observability
+    literals:
+      - profiling.enable="true"
 
 patches:
   - path: api-db-config.yaml


### PR DESCRIPTION
per the golang recommendations that pprof enablement is OK in production, we are enabling to allow for gathering goroutine dumps as part of diagnosing deadlocks.

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED