### PR TITLE
SRVKP-5832: move to downstream images to quay.io/konflux-ci

### DIFF
--- a/operator/gitops/argocd/pipeline-service/tekton-results/kustomization.yaml
+++ b/operator/gitops/argocd/pipeline-service/tekton-results/kustomization.yaml
@@ -12,10 +12,10 @@ resources:
 
 images:
   - name: ko://github.com/tektoncd/results/cmd/api
-    newName: quay.io/redhat-appstudio/tekton-results-api
+    newName: quay.io/konflux-ci/tekton-results-api
     newTag: e35af9274c0df84386b73aae8df0ad496ad175df
   - name: ko://github.com/tektoncd/results/cmd/watcher
-    newName: quay.io/redhat-appstudio/tekton-results-watcher
+    newName: quay.io/konflux-ci/tekton-results-watcher
     newTag: e35af9274c0df84386b73aae8df0ad496ad175df
 
 # generate a new configmap with updated values (logs api, db ssl mode) and replace the default one


### PR DESCRIPTION
fyi no direct image specs in Deployments in https://github.com/openshift-pipelines/pipeline-service/tree/main/operator/gitops/argocd/pipeline-service/tekton-results

that said let's wait until https://github.com/openshift-pipelines/tektoncd-results/pull/70 merges to confirm

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED