### PR TITLE
add OSP pruner back as backup to results

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -190,4 +190,13 @@ spec:
       kube-api-qps: 50
       kube-api-burst: 50
   pruner:
-    disabled: true
+      # The load on prod-rh01 is to the point now where tekton-results
+      # can fall too far behind.  Until the watcher's log storage is rewritten
+      # etc with SRVKP-4347 or if we risk adding more processing power (threads,qps,burst)
+      # to the mem leak version of the watcher, we need the OSP pruner as a backup.
+      # a bit of an adjustment, we will prune once an hour now per https://crontab.guru/every-1-hour
+      # to line up with typical timeout settings.
+      keep: 10
+      resources:
+        - pipelinerun
+      schedule: 0 * * * *


### PR DESCRIPTION
see https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721742678863629

@enarha @gbenhaim

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED