### PR TITLE
SRVKP-4532: add resolver crd to exporter permissions

### DIFF
--- a/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrole.yaml
+++ b/operator/gitops/argocd/pipeline-service/metrics-exporter/clusterrole.yaml
@@ -17,8 +17,8 @@ rules:
     verbs:
       - get
 
-  - apiGroups: ["tekton.dev"]
-    resources: ["pipelineruns", "taskruns"]
+  - apiGroups: ["tekton.dev", "resolution.tekton.dev"]
+    resources: ["pipelineruns", "taskruns", "resolutionrequests"]
     verbs: ["get", "list", "watch", "patch"]
 
   - nonResourceURLs:


### PR DESCRIPTION
For new resolver deadlock metric given recent hangs/crashloops

Metric coming with https://github.com/openshift-pipelines/pipeline-service-exporter/pull/71

@enarha @savitaashture @khrm @divyansh42 FYI

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED