### PR TITLE
disable pruning temporarily, work around weird operator validation error

### DIFF
--- a/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
+++ b/operator/gitops/argocd/pipeline-service/openshift-pipelines/tekton-config.yaml
@@ -190,12 +190,4 @@ spec:
       kube-api-qps: 50
       kube-api-burst: 50
   pruner:
-    # The load on prod-rh01 is to the point now where tekton-results
-    # can fall too far behind.  Until the watcher's log storage is rewritten
-    # etc with SRVKP-4347 or if we risk adding more processing power (threads,qps,burst)
-    # to the mem leak version of the watcher, we need the OSP pruner as a backup.
-    disable: false
-    keep-since: 60
-    resources:
-      - pipelinerun
-    schedule: "*/10 * * * *"
+    disabled: true


### PR DESCRIPTION
after fixing the pruner config typo, using disabled instead of disable, kept getting this inexplicable error in the operator validating webhook, even though only 'keep-since' was used and not 'keep'

`validation failed: expected exactly one, got both: spec.pruner.keep, spec.pruner.keep-since,Reason:BadRequest,Details:nil,Code:400,`

only disabling pruning seems to bypass this error in my `fix-pruner-cfg` branch here.

Currently main branch fails dev_setup.sh with the typo.

so @enarha @divyansh42 yeah there is some weird impl detail with gitops in conjunction with tekton operator

In fact after first changing line 197 in the file to say `disabled` vs. `disable` and seeing the validation error above, and then just disabling the pruner, when I ran

`oc get tektonconfig config -o yaml -w` I would see yaml bits like 

```
  pruner:
    disabled: true
    keep: 100
```

where maybe `keep: 100` is some default setting the operator does ???   Note that last use of `keep` with https://github.com/openshift-pipelines/pipeline-service/commit/c12b16367788ca6e4f67e4cdd41ff891abcba77e set it to `10` so I don't thing this is gitops looking at older commits or something

my best guess this is an operator bug @enarha where maybe there is a version difference between the operator in main branch of this repo and what we have in konflux prod, hence we don't see this error with https://github.com/redhat-appstudio/infra-deployments/blob/main/components/pipeline-service/production/base/update-tekton-config-performance.yaml#L34-L41 .... or it is a timing issue where gitops replacing the operator default somehow luckily works @enarha  ... something to keep an eye on the next time prod is bumped

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED